### PR TITLE
Add manual strategy

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,7 +6,8 @@ spark_locals_without_parens = [
   text: 1,
   tool: 3,
   tool: 4,
-  used_attributes: 1
+  used_attributes: 1,
+  define_update_action_for_manual_strategy?: 1
 ]
 
 [

--- a/lib/ash_ai/changes/vectorize.ex
+++ b/lib/ash_ai/changes/vectorize.ex
@@ -1,0 +1,61 @@
+defmodule AshAi.Changes.Vectorize do
+  use Ash.Resource.Change
+
+  def change(changeset, opts, context) do
+    {embedding_model, vector_opts} =
+      AshAi.Info.vectorize_embedding_model!(changeset.resource)
+
+    attrs =
+      AshAi.Info.vectorize_attributes!(changeset.resource)
+
+    name = AshAi.Info.vectorize_full_text_name!(changeset.resource)
+
+    attrs =
+      AshAi.Info.vectorize_attributes!(changeset.resource)
+
+    changes =
+      case AshAi.Info.vectorize_full_text_text(changeset.resource) do
+        {:ok, fun} ->
+          used_attrs =
+            case AshAi.Info.vectorize_full_text_used_attributes(changeset.resource) do
+              {:ok, attrs} -> attrs
+              _ -> nil
+            end
+
+          attrs ++
+            [{:full_text, name, used_attrs, fun}]
+
+        _ ->
+          attrs
+      end
+      |> Enum.flat_map(fn
+        {source, dest} ->
+          text = Map.get(changeset.data, source)
+          [{dest, text}]
+
+        {:full_text, name, _used_attrs, fun} ->
+          text = fun.(changeset.data)
+          [{name, text}]
+      end)
+
+    strings = Enum.map(changes, &elem(&1, 1))
+
+    case embedding_model.generate(strings, vector_opts) do
+      {:ok, vectors} ->
+        changes =
+          Enum.zip_with(changes, vectors, fn {k, _}, r ->
+            {k, r}
+          end)
+
+        Ash.Changeset.change_attributes(changeset, changes)
+
+      {:error, error} ->
+        fields = Enum.map(changes, fn {field, _} -> field end)
+        Ash.Changeset.add_error(changeset, fields: fields, message: "Error while vectorizing")
+    end
+  end
+
+  def atomic(changeset, opts, context) do
+    {:ok, change(changeset, opts, context)}
+  end
+end


### PR DESCRIPTION
Adds a `:manual` strategy in addition to the existing `:after_action` strategy.

By default, this strategy will also set up an update action called `ash_ai_update_embeddings`, which will update the embeddings according to the record's current values when run.

The logic for updating the embeddings are located in the `AshAi.Changes.Vectorize`-change module, which can also be utilized outside of this action if needed.

Adds a new flag `define_update_action_for_manual_strategy?` to the `vectorize`-section, which can be set to false if the action is not needed.

Also adds a `AshAi.has_vectorize_change?`-helper, that can check if a changeset has changes that requires the embeddings to be updated.