### PR TITLE
Add tenant to opts of setup_ash_ai/2

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -123,6 +123,10 @@ defmodule AshAi do
           type: :any,
           doc: "The actor performing any actions."
         ],
+        tenant: [
+          type: {:protocol, Ash.ToTenant},
+          doc: "The tenant to use for the action."
+        ],
         messages: [
           type: {:list, :map},
           default: [],
@@ -775,7 +779,8 @@ defmodule AshAi do
             opts.actor,
             domain,
             tool.resource,
-            action
+            action,
+            opts.tenant
           ) do
         %{tool | domain: domain, action: Ash.Resource.Info.action(tool.resource, tool.action)}
       end
@@ -817,7 +822,12 @@ defmodule AshAi do
     end)
   end
 
-  defp can?(actor, domain, resource, action) do
-    Ash.can?({resource, action}, actor, domain: domain, maybe_is: true, run_queries?: false)
+  defp can?(actor, domain, resource, action, tenant) do
+    Ash.can?({resource, action}, actor,
+      tenant: tenant,
+      domain: domain,
+      maybe_is: true,
+      run_queries?: false
+    )
   end
 end

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -198,7 +198,7 @@ defmodule AshAi do
     |> LLMChain.add_callback(handler)
     |> then(fn llm_chain ->
       if opts.actor do
-        LLMChain.update_custom_context(llm_chain, %{actor: opts.actor})
+        LLMChain.update_custom_context(llm_chain, %{actor: opts.actor, tenant: opts.tenant})
       else
         llm_chain
       end

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -66,8 +66,8 @@ defmodule AshAi.Actions.Prompt do
           AshAi.functions(
             otp_app: otp_app,
             exclude_actions: [{input.resource, input.action.name}],
-            actor: context[:actor],
-            tenant: context[:tenant]
+            actor: context.actor,
+            tenant: context.tenant
           )
 
         tools ->
@@ -80,8 +80,8 @@ defmodule AshAi.Actions.Prompt do
             tools: List.wrap(tools),
             otp_app: otp_app,
             exclude_actions: [{input.resource, input.action.name}],
-            actor: context[:actor],
-            tenant: context[:tenant]
+            actor: context.actor,
+            tenant: context.tenant
           )
       end
 

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -65,7 +65,9 @@ defmodule AshAi.Actions.Prompt do
 
           AshAi.functions(
             otp_app: otp_app,
-            exclude_actions: [{input.resource, input.action.name}]
+            exclude_actions: [{input.resource, input.action.name}],
+            actor: context[:actor],
+            tenant: context[:tenant]
           )
 
         tools ->
@@ -77,7 +79,9 @@ defmodule AshAi.Actions.Prompt do
           AshAi.functions(
             tools: List.wrap(tools),
             otp_app: otp_app,
-            exclude_actions: [{input.resource, input.action.name}]
+            exclude_actions: [{input.resource, input.action.name}],
+            actor: context[:actor],
+            tenant: context[:tenant]
           )
       end
 


### PR DESCRIPTION
`Ash.can?/3` requires `tenant` to be specified in some cases. This change allows passing the tenant via the `opts` of `setup_ash_ai/2`.