### PR TITLE
Fix schema type of actions of Options

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -102,9 +102,11 @@ defmodule AshAi do
     use Spark.Options.Validator,
       schema: [
         actions: [
-          type: {:wrap_list, {:tuple, [{:spark, Ash.Resource}, :atom]}},
+          type:
+            {:wrap_list,
+             {:tuple, [{:spark, Ash.Resource}, {:or, [{:list, :atom}, {:literal, :*}]}]}},
           doc: """
-          A set of {Resource, :action} pairs, or `{Resource, :*}` for all actions. Defaults to everything. If `tools` is also set, both are applied as filters.
+          A set of {Resource, [:action]} pairs, or `{Resource, :*}` for all actions. Defaults to everything. If `tools` is also set, both are applied as filters.
           """
         ],
         tools: [


### PR DESCRIPTION
According to the code below, actions should be either a list of action names or `:*`.

https://github.com/nallwhy/ash_ai/blob/fix_schema_type_of_actions_of_options/lib/ash_ai.ex#L750-L754