### PR TITLE
Fix nil input in function/4

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -303,6 +303,7 @@ defmodule AshAi do
       function: fn arguments, context ->
         actor = context[:actor]
         tenant = context[:tenant]
+        input = arguments["input"] || %{}
 
         try do
           case action.type do
@@ -339,7 +340,7 @@ defmodule AshAi do
                   query
                 end
               end)
-              |> Ash.Query.for_read(action.name, arguments["input"] || %{},
+              |> Ash.Query.for_read(action.name, input,
                 domain: domain,
                 actor: actor,
                 tenant: tenant
@@ -367,7 +368,7 @@ defmodule AshAi do
 
               resource
               |> Ash.get!(pkey)
-              |> Ash.Changeset.for_update(action.name, arguments["input"],
+              |> Ash.Changeset.for_update(action.name, input,
                 domain: domain,
                 actor: actor,
                 tenant: tenant
@@ -388,7 +389,7 @@ defmodule AshAi do
 
               resource
               |> Ash.get!(pkey)
-              |> Ash.Changeset.for_destroy(action.name, arguments["input"],
+              |> Ash.Changeset.for_destroy(action.name, input,
                 domain: domain,
                 actor: actor,
                 tenant: tenant
@@ -403,7 +404,7 @@ defmodule AshAi do
 
             :create ->
               resource
-              |> Ash.Changeset.for_create(action.name, arguments["input"],
+              |> Ash.Changeset.for_create(action.name, input,
                 domain: domain,
                 actor: actor,
                 tenant: tenant
@@ -418,7 +419,7 @@ defmodule AshAi do
 
             :action ->
               resource
-              |> Ash.ActionInput.for_action(action.name, arguments["input"],
+              |> Ash.ActionInput.for_action(action.name, input,
                 domain: domain,
                 actor: actor,
                 tenant: tenant


### PR DESCRIPTION
This PR fixes a crash caused by a `nil` value being passed as the input to an action.

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for type Atom

Got value:

    nil

    (elixir 1.18.3) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.18.3) lib/enum.ex:166: Enumerable.reduce/3
    (elixir 1.18.3) lib/enum.ex:4515: Enum.reverse/1
    (elixir 1.18.3) lib/enum.ex:3835: Enum.to_list/1
    (elixir 1.18.3) lib/enum.ex:1544: Enum.into_map/1
    (ash 3.5.0) lib/ash/action_input.ex:299: Ash.ActionInput.cast_params/3
    (ash 3.5.0) lib/ash/action_input.ex:134: Ash.ActionInput.for_action/4
    iex:2: (file)
```