### PR TITLE
Add tests for setup_ash_ai

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :ash, :validate_domain_resource_inclusion?, false
+config :ash, :validate_domain_config_inclusion?, false

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -247,7 +247,7 @@ defmodule AshAi do
         |> LLMChain.add_messages([LangChain.Message.new_user!(user_message)])
         |> run_loop()
 
-      {:error, error} ->
+      {:error, _new_chain, error} ->
         raise "Something went wrong:\n #{Exception.format(:error, error)}"
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule AshAi.MixProject do
       app: :ash_ai,
       version: "0.1.0",
       elixir: "~> 1.17",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()
@@ -17,6 +18,14 @@ defmodule AshAi.MixProject do
     [
       extra_applications: [:logger]
     ]
+  end
+
+  defp elixirc_paths(:test) do
+    ["test/support/", "lib/"]
+  end
+
+  defp elixirc_paths(_env) do
+    ["lib/"]
   end
 
   # Run "mix help deps" to learn about dependencies.

--- a/test/ash_ai_test.exs
+++ b/test/ash_ai_test.exs
@@ -1,8 +1,79 @@
 defmodule AshAiTest do
-  use ExUnit.Case
-  doctest AshAi
+  use ExUnit.Case, async: true
+  alias AshAi.ChatFaker
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Message
+  alias __MODULE__.{Blogs, Author}
 
-  test "greets the world" do
-    assert AshAi.hello() == :world
+  defmodule Author do
+    use Ash.Resource, domain: Blogs, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key(:id, writable?: true)
+      attribute(:name, :string, public?: true)
+    end
+
+    actions do
+      default_accept([:*])
+      defaults([:create, :read, :update, :destroy])
+    end
+  end
+
+  defmodule Blogs do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource(Author)
+    end
+
+    tools do
+      tool(:create_author, Author, :create)
+    end
+  end
+
+  describe "setup_ash_ai" do
+    test "with create action" do
+      expect_fun = fn _chat_model, messages, _tools ->
+        Message.new_assistant(%{processed_content: last_processed_content(messages)})
+      end
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "create_author",
+        arguments: %{
+          "input" => %{
+            "name" => "Chet Baker"
+          }
+        },
+        index: 0
+      }
+
+      assert {:ok, new_chain} = run_chain(expect_fun, tool_call)
+
+      assert %Author{name: "Chet Baker"} = new_chain.last_message.processed_content
+    end
+  end
+
+  defp run_chain(expect_fun, tool_call) do
+    actions =
+      AshAi.Info.tools(Blogs)
+      |> Enum.group_by(& &1.resource, & &1.action)
+      |> Map.to_list()
+
+    %{llm: ChatFaker.new!(%{expect_fun: expect_fun})}
+    |> LLMChain.new!()
+    |> AshAi.setup_ash_ai(actions: actions)
+    |> LLMChain.add_message(Message.new_assistant!(%{status: :complete, tool_calls: [tool_call]}))
+    |> LLMChain.run(mode: :while_needs_response)
+  end
+
+  defp last_processed_content(messages) do
+    messages
+    |> List.last()
+    |> Map.get(:tool_results)
+    |> List.first()
+    |> Map.get(:processed_content)
   end
 end

--- a/test/support/chat_fake.ex
+++ b/test/support/chat_fake.ex
@@ -1,0 +1,37 @@
+defmodule AshAi.ChatFaker do
+  @behaviour LangChain.ChatModels.ChatModel
+
+  alias LangChain.Message
+
+  defstruct [
+    # required for chat models
+    callbacks: [],
+    expect_fun: nil
+  ]
+
+  def new!(attrs) do
+    struct(__MODULE__, attrs)
+  end
+
+  @impl true
+  def call(%__MODULE__{expect_fun: expect_fun} = chat_model, messages, tools)
+      when is_list(messages) and is_list(tools) do
+    case expect_fun do
+      expect_fun when is_function(expect_fun) ->
+        expect_fun.(chat_model, messages, tools)
+
+      nil ->
+        Message.new_assistant(%{content: "Good!"})
+    end
+  end
+
+  @impl true
+  def restore_from_map(_data) do
+    raise "Not implemented"
+  end
+
+  @impl true
+  def serialize_config(_model) do
+    raise "Not implemented"
+  end
+end


### PR DESCRIPTION
I thought it was about time to start adding some tests, so I created a `ChatFaker` that follows the `langchain` spec. It allows us to verify the execution results of tools stored in `processed_content`.

If this approach looks good, I plan to add more tests for other actions as well.