### PR TITLE
Add tests for all action types of tools

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -396,7 +396,7 @@ defmodule AshAi do
               resource
               |> Ash.get!(pkey)
               |> Ash.Changeset.for_destroy(action.name, input, opts)
-              |> Ash.destroy!()
+              |> Ash.destroy!(return_destroyed?: true)
               |> then(fn result ->
                 result
                 |> AshJsonApi.Serializer.serialize_value(resource, [], domain, load: load)
@@ -417,7 +417,7 @@ defmodule AshAi do
 
             :action ->
               resource
-              |> Ash.ActionInput.for_action(action.name, input, opts)
+              |> Ash.ActionInput.for_action(action.name, input, opts |> Keyword.drop([:load]))
               |> Ash.run_action!()
               |> then(fn result ->
                 if action.returns do

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -66,7 +66,7 @@ defmodule AshAi do
 
   defmodule Tool do
     @moduledoc "An action exposed to LLM agents"
-    defstruct [:name, :resource, :action, :load, :domain]
+    defstruct [:name, :resource, :action, :load, :async, :domain]
   end
 
   @tool %Spark.Dsl.Entity{
@@ -76,7 +76,8 @@ defmodule AshAi do
       name: [type: :atom, required: true],
       resource: [type: {:spark, Ash.Resource}, required: true],
       action: [type: :atom, required: true],
-      load: [type: :any, default: []]
+      load: [type: :any, default: []],
+      async: [type: :boolean, default: true]
     ],
     args: [:name, :resource, :action]
   }
@@ -288,7 +289,14 @@ defmodule AshAi do
     |> Jason.decode!()
   end
 
-  defp function(%Tool{name: name, domain: domain, resource: resource, action: action, load: load}) do
+  defp function(%Tool{
+         name: name,
+         domain: domain,
+         resource: resource,
+         action: action,
+         load: load,
+         async: async
+       }) do
     name = to_string(name)
 
     description =
@@ -302,6 +310,7 @@ defmodule AshAi do
       description: description,
       parameters_schema: parameter_schema,
       strict: true,
+      async: async,
       function: fn arguments, context ->
         actor = context[:actor]
         tenant = context[:tenant]

--- a/test/ash_ai_test.exs
+++ b/test/ash_ai_test.exs
@@ -3,10 +3,14 @@ defmodule AshAiTest do
   alias AshAi.ChatFaker
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
-  alias __MODULE__.{Blogs, Author}
+  alias __MODULE__.{Music, Artist}
 
-  defmodule Author do
-    use Ash.Resource, domain: Blogs, data_layer: Ash.DataLayer.Ets
+  defmodule Artist do
+    use Ash.Resource, domain: Music, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
 
     attributes do
       uuid_primary_key(:id, writable?: true)
@@ -16,55 +20,116 @@ defmodule AshAiTest do
     actions do
       default_accept([:*])
       defaults([:create, :read, :update, :destroy])
+
+      action :say_hello, :string do
+        argument(:name, :string, allow_nil?: false)
+
+        run(fn input, _ ->
+          {:ok, "Hello: #{input.arguments.name}"}
+        end)
+      end
     end
   end
 
-  defmodule Blogs do
+  defmodule Music do
     use Ash.Domain, extensions: [AshAi]
 
     resources do
-      resource(Author)
+      resource(Artist)
     end
 
     tools do
-      tool(:create_author, Author, :create)
+      tool(:list_artists, Artist, :read, async: false)
+      tool(:create_artist, Artist, :create, async: false)
+      tool(:update_artist, Artist, :update, async: false)
+      tool(:delete_artist, Artist, :destroy, async: false)
+      tool(:say_hello, Artist, :say_hello, async: false)
     end
   end
 
   describe "setup_ash_ai" do
+    setup do
+      artist =
+        Artist
+        |> Ash.Changeset.for_create(:create, %{name: "Chet Baker"})
+        |> Ash.create!()
+
+      %{artist: artist}
+    end
+
+    test "with read action", %{artist: artist} do
+      tool_call = tool_call("list_artists", %{"filter" => %{"name" => %{"eq" => artist.name}}})
+
+      assert {:ok, new_chain} = chain() |> run_chain(tool_call)
+
+      assert [fetched_artist] = new_chain.last_message.processed_content
+      assert fetched_artist.id == artist.id
+    end
+
     test "with create action" do
-      expect_fun = fn _chat_model, messages, _tools ->
-        Message.new_assistant(%{processed_content: last_processed_content(messages)})
-      end
+      tool_call = tool_call("create_artist", %{"input" => %{"name" => "Chat Faker"}})
 
-      tool_call = %LangChain.Message.ToolCall{
-        status: :complete,
-        type: :function,
-        call_id: "call_id",
-        name: "create_author",
-        arguments: %{
-          "input" => %{
-            "name" => "Chet Baker"
-          }
-        },
-        index: 0
-      }
+      assert {:ok, new_chain} = chain() |> run_chain(tool_call)
 
-      assert {:ok, new_chain} = run_chain(expect_fun, tool_call)
+      assert %Artist{name: "Chat Faker"} = new_chain.last_message.processed_content
+    end
 
-      assert %Author{name: "Chet Baker"} = new_chain.last_message.processed_content
+    test "with update action", %{artist: artist} do
+      tool_call =
+        tool_call("update_artist", %{"id" => artist.id, "input" => %{"name" => "Chat Faker"}})
+
+      assert {:ok, new_chain} = chain() |> run_chain(tool_call)
+
+      assert %Artist{name: "Chat Faker"} = new_chain.last_message.processed_content
+    end
+
+    test "with destroy action", %{artist: artist} do
+      tool_call = tool_call("delete_artist", %{"id" => artist.id})
+
+      assert {:ok, new_chain} = chain() |> run_chain(tool_call)
+
+      assert %Artist{name: "Chet Baker"} = new_chain.last_message.processed_content
+    end
+
+    test "with action" do
+      tool_call = tool_call("say_hello", %{"input" => %{"name" => "Chat Faker"}})
+
+      assert {:ok, new_chain} = chain() |> run_chain(tool_call)
+
+      assert "Hello: Chat Faker" = new_chain.last_message.processed_content
     end
   end
 
-  defp run_chain(expect_fun, tool_call) do
+  defp tool_call(name, arguments) do
+    %LangChain.Message.ToolCall{
+      status: :complete,
+      type: :function,
+      call_id: "call_id",
+      name: name,
+      arguments: arguments,
+      index: 0
+    }
+  end
+
+  defp chain() do
     actions =
-      AshAi.Info.tools(Blogs)
+      AshAi.Info.tools(Music)
       |> Enum.group_by(& &1.resource, & &1.action)
       |> Map.to_list()
 
-    %{llm: ChatFaker.new!(%{expect_fun: expect_fun})}
+    %{llm: ChatFaker.new!(%{expect_fun: expect_fun()})}
     |> LLMChain.new!()
     |> AshAi.setup_ash_ai(actions: actions)
+  end
+
+  defp expect_fun() do
+    fn _chat_model, messages, _tools ->
+      Message.new_assistant(%{processed_content: last_processed_content(messages)})
+    end
+  end
+
+  defp run_chain(chain, tool_call) do
+    chain
     |> LLMChain.add_message(Message.new_assistant!(%{status: :complete, tool_calls: [tool_call]}))
     |> LLMChain.run(mode: :while_needs_response)
   end


### PR DESCRIPTION
- Add `async` option to tool
- Add tests for all action types of tools
- Fix bug in `destroy` action type (was not returning the destroyed resource)
- Fix bug in `action` action type (`load` option was causing a crash)