### PR TITLE
don't reply to the initialized notification

### DIFF
--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -347,7 +347,7 @@ defmodule AshAi.Mcp.Server do
 
         {:json_response, Jason.encode!(response), session_id}
 
-      %{"method" => _method, "params" => _params} ->
+      %{"method" => _method} ->
         # Handle other notifications (no id)
         {:no_response, nil, session_id}
 


### PR DESCRIPTION
I did not add any tests here, but with that change, the upcoming update of the Tidewave Rust MCP proxy works with Ash AI, as long as you set the protocol version to `2024-11-05`:

![image](https://github.com/user-attachments/assets/7bc71c3c-9feb-4c99-b6f6-887da4db96b3)

The issue is that according to the spec, the initialized notification looks like this

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/initialized"
}
```

but AshAI's MCP server would reply with an error to that request:

```json
{"error":{"code":-32600,"message":"Invalid Request"},"id":null,"jsonrpc":"2.0"}
```