### PR TITLE
docs: Update vector search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,15 @@ read :search do
       {:ok, [search_vector]} ->
         Ash.Query.filter(
           query,
-          vector_cosine_distance(full_text_vector, ^vector) < 0.5
+          vector_cosine_distance(full_text_vector, ^search_vector) < 0.5
         )
+        |> Ash.Query.sort(
+          {calc(vector_cosine_distance(full_text_vector, ^search_vector),
+             type: :float
+           ), :asc}
+        )
+        |> Ash.Query.limit(10)
+
       {:error, error} ->
         {:error, error}
     end


### PR DESCRIPTION
The vector search example doesn't work as written because it references a non-existent variable name and lacked a sort clause. 

This commit updates it using the `calc` expr as recommended by Zach on discord for sort, and adds a `limit` expression to make it more of a full working example.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
