### PR TITLE
use after_action instead of after_transaction to afford atomic_updates

### DIFF
--- a/lib/ash_ai/changes/vectorize_after_action_oban_trigger.ex
+++ b/lib/ash_ai/changes/vectorize_after_action_oban_trigger.ex
@@ -5,19 +5,16 @@ if Code.ensure_loaded?(AshOban) do
 
     # TODO add bulk action callbacks here?
     def change(changeset, module_opts, _context) do
-      Ash.Changeset.after_transaction(changeset, fn
-        _changeset, {:error, error} ->
-          {:error, error}
-
-        changeset, {:ok, result} ->
+      Ash.Changeset.after_action(changeset, fn
+        changeset, record ->
           if changeset.action.name == :ash_ai_update_embeddings do
-            {:ok, result}
+            {:ok, record}
           else
             if AshAi.has_vectorize_change?(changeset) do
-              %Oban.Job{} = AshOban.run_trigger(result, module_opts[:trigger_name])
+              %Oban.Job{} = AshOban.run_trigger(record, module_opts[:trigger_name])
             end
 
-            {:ok, result}
+            {:ok, record}
           end
       end)
     end


### PR DESCRIPTION
Uses after_action instead of after_transaction so that actions can still be fully atomic for resources that use the `vectorize` option with both :after_action and :oban_after_action strategies. 

Context: https://discord.com/channels/711271361523351632/1349578223515734037/1377056058085871658

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests 
