### PR TITLE
docs: Add missing end of map in using iex chat code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ defmodule MyApp.ChatBot do
 
   def iex_chat(actor \\ nil) do
     %{
-      llm: ChatOpenAI.new!(%{model: "gpt-4o", stream: true),
+      llm: ChatOpenAI.new!(%{model: "gpt-4o", stream: true}),
       verbose: true
     }
     |> LLMChain.new!()


### PR DESCRIPTION
regarding in docs for 
> How to play with it
>  1. Setup `LangChain`

I assume that means adding to config
```
config :langchain, openai_key: System.fetch_env!("OPENAI_API_KEY")
config :langchain, openai_org_id: System.fetch_env!("OPENAI_ORG_ID")
```
perhaps a link to the config part in Setup would be useful.


> 2. Modify a `LangChain` using `AshiAi.setup_ash_ai`

it's not clear what and why :thinking: 
> Run `iex -S mix` and then run `AshAi.iex_chat` to start chatting with your app.
Previously this worked with nil but now AFAIS a setup is in order similar to step 4.
I did
`llm = LangChain.ChatModels.ChatOpenAI.new! %{model: "gpt-4o-mini", stream: true}`
`lang_chain = LangChain.Chains.LLMChain.new! %{llm: llm, verbose: true}`
`AshAi.iex_chat lang_chain, otp_app: :my_app`

Which worked. I think there should be a part for setting it up from iex directly, and the 4th step.
Maybe something like `## Using AshAi.iex_chat` which would represent local setup more verbosely and `## Define your Chat Bot` which is code block of step 4. And then maybe instead of `# How to play with it` it could be the LangChain setup part which is relevant for both setups; instead of a link it should be the above config code.

Just some ideas for possible docs improvement. 🐛 


### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
