### PR TITLE
more context in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,11 @@ end
 2. Run `iex -S mix` and then run `AshAi.iex_chat` to start chatting with your app.
 3. Build your own chat interface. See the implementation of `AshAi.iex_chat` to see how its done.
 
+## Contributing 
+
+1. make sure to run `mix test.create && mix test.migrate` to set up locally
+1. ensure that `mix check` passes
+
 ## Using AshAi.iex_chat
 
 ```elixir

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -25,6 +25,7 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
 
   @default_max_retries 2
   @json_markdown_regex ~r/```json\s*(.*?)\s*```/s
+  @json_xml_regex ~r/<json>\s*(.*?)\s*<\/json>/s
 
   def run(%Data{} = data, opts) do
     max_retries = opts[:max_retries] || @default_max_retries
@@ -38,7 +39,13 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
       Message.new_user!(data.user_message)
     ]
 
-    json_processor = JsonProcessor.new!(@json_markdown_regex)
+    regex =
+      case json_format do
+        :xml -> @json_xml_regex
+        _ -> @json_markdown_regex
+      end
+
+    json_processor = JsonProcessor.new!(regex)
 
     chain =
       %{

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -8,6 +8,7 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
+  alias LangChain.LangChainError
   alias LangChain.Message
 
   def run(%Data{} = data, _opts) do
@@ -50,27 +51,58 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
          last_message: %{content: content}
        }}
       when is_binary(content) ->
-        with {:ok, decoded} <- Jason.decode(content),
-             {:ok, value} <-
-               Ash.Type.cast_input(
-                 data.input.action.returns,
-                 decoded["result"],
-                 data.input.action.constraints
-               ),
-             {:ok, value} <-
-               Ash.Type.apply_constraints(
-                 data.input.action.returns,
-                 value,
-                 data.input.action.constraints
-               ) do
-          {:ok, value}
-        else
-          _error ->
-            {:error, "Invalid LLM response"}
-        end
+        process_llm_response(content, data)
 
       {:error, _, error} ->
         {:error, error}
     end
   end
+
+  defp process_llm_response(content, data) do
+    with {:json_decode, {:ok, decoded}} <- {:json_decode, Jason.decode(content)},
+         {:cast_input, {:ok, value}} <- cast_to_type(decoded["result"], data),
+         {:apply_constraints, {:ok, value}} <- validate_constraints(value, data) do
+      {:ok, value}
+    else
+      error ->
+        {:error, format_error(error, content)}
+    end
+  end
+
+  defp cast_to_type(result, data) do
+    {:cast_input,
+     Ash.Type.cast_input(
+       data.input.action.returns,
+       result,
+       data.input.action.constraints
+     )}
+  end
+
+  defp validate_constraints(value, data) do
+    {:apply_constraints,
+     Ash.Type.apply_constraints(
+       data.input.action.returns,
+       value,
+       data.input.action.constraints
+     )}
+  end
+
+  defp format_error({:json_decode, {:error, %Jason.DecodeError{} = decode_error}}, content) do
+    "Failed to decode JSON response: #{Exception.message(decode_error)}. Raw LLM Response: #{inspect(content)}"
+  end
+
+  defp format_error({:cast_input, {:error, error}}, content) do
+    "Failed to cast LLM response to expected type: #{format_type_error(error)}. Raw LLM Response: #{inspect(content)}"
+  end
+
+  defp format_error({:apply_constraints, {:error, error}}, content) do
+    "LLM response failed constraint validation: #{format_type_error(error)}. Raw LLM Response: #{inspect(content)}"
+  end
+
+  defp format_error(error, content) do
+    "Invalid LLM response: #{inspect(error)}. Raw LLM Response: #{inspect(content)}"
+  end
+
+  defp format_type_error(error) when is_binary(error), do: error
+  defp format_type_error(error), do: inspect(error)
 end

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -8,7 +8,6 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
-  alias LangChain.LangChainError
   alias LangChain.Message
 
   def run(%Data{} = data, _opts) do

--- a/test/ash_ai/actions/prompt/adapter/completion_test.exs
+++ b/test/ash_ai/actions/prompt/adapter/completion_test.exs
@@ -57,35 +57,36 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
         argument(:text, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, _messages, tools ->
-                completion_tool = Enum.find(tools, &(&1.name == "complete_request"))
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, _messages, tools ->
+                    completion_tool = Enum.find(tools, &(&1.name == "complete_request"))
 
-                tool_call = %LangChain.Message.ToolCall{
-                  status: :complete,
-                  type: :function,
-                  call_id: "call_123",
-                  name: "complete_request",
-                  arguments: %{
-                    "result" => %{
-                      "sentiment" => "positive",
-                      "confidence" => 0.92,
-                      "keywords" => ["excellent", "wonderful", "fantastic"]
+                    tool_call = %LangChain.Message.ToolCall{
+                      status: :complete,
+                      type: :function,
+                      call_id: "call_123",
+                      name: "complete_request",
+                      arguments: %{
+                        "result" => %{
+                          "sentiment" => "positive",
+                          "confidence" => 0.92,
+                          "keywords" => ["excellent", "wonderful", "fantastic"]
+                        }
+                      },
+                      index: 0
                     }
-                  },
-                  index: 0
-                }
 
-                {:ok, LangChain.Message.new_assistant!(%{
-                  status: :complete,
-                  tool_calls: [tool_call]
-                })}
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.CompletionTool, [max_runs: 10]}
-        )
+                    {:ok,
+                     LangChain.Message.new_assistant!(%{
+                       status: :complete,
+                       tool_calls: [tool_call]
+                     })}
+                  end
+                })
+              end,
+              adapter: {AshAi.Actions.Prompt.Adapter.CompletionTool, [max_runs: 10]}
+            )
       end
 
       action :generate_summary, Summary do
@@ -94,35 +95,36 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
         argument(:max_words, :integer, allow_nil?: true)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, _messages, tools ->
-                completion_tool = Enum.find(tools, &(&1.name == "complete_request"))
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, _messages, tools ->
+                    completion_tool = Enum.find(tools, &(&1.name == "complete_request"))
 
-                tool_call = %LangChain.Message.ToolCall{
-                  status: :complete,
-                  type: :function,
-                  call_id: "call_456",
-                  name: "complete_request",
-                  arguments: %{
-                    "result" => %{
-                      "summary" => "A well-written document about machine learning concepts.",
-                      "word_count" => 58,
-                      "key_points" => ["AI fundamentals", "Neural networks", "Deep learning"]
+                    tool_call = %LangChain.Message.ToolCall{
+                      status: :complete,
+                      type: :function,
+                      call_id: "call_456",
+                      name: "complete_request",
+                      arguments: %{
+                        "result" => %{
+                          "summary" => "A well-written document about machine learning concepts.",
+                          "word_count" => 58,
+                          "key_points" => ["AI fundamentals", "Neural networks", "Deep learning"]
+                        }
+                      },
+                      index: 0
                     }
-                  },
-                  index: 0
-                }
 
-                {:ok, LangChain.Message.new_assistant!(%{
-                  status: :complete,
-                  tool_calls: [tool_call]
-                })}
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.CompletionTool, [max_runs: 5]}
-        )
+                    {:ok,
+                     LangChain.Message.new_assistant!(%{
+                       status: :complete,
+                       tool_calls: [tool_call]
+                     })}
+                  end
+                })
+              end,
+              adapter: {AshAi.Actions.Prompt.Adapter.CompletionTool, [max_runs: 5]}
+            )
       end
     end
   end
@@ -147,37 +149,40 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
         argument(:text, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, _messages, _tools ->
-                # Return invalid data type (string instead of float for confidence)
-                tool_call = %LangChain.Message.ToolCall{
-                  status: :complete,
-                  type: :function,
-                  call_id: "call_validation",
-                  name: "complete_request",
-                  arguments: %{
-                    "result" => %{
-                      "sentiment" => "positive",
-                      "confidence" => "not a number",
-                      "keywords" => ["good"]
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, _messages, _tools ->
+                    # Return invalid data type (string instead of float for confidence)
+                    tool_call = %LangChain.Message.ToolCall{
+                      status: :complete,
+                      type: :function,
+                      call_id: "call_validation",
+                      name: "complete_request",
+                      arguments: %{
+                        "result" => %{
+                          "sentiment" => "positive",
+                          "confidence" => "not a number",
+                          "keywords" => ["good"]
+                        }
+                      },
+                      index: 0
                     }
-                  },
-                  index: 0
-                }
 
-                {:ok, LangChain.Message.new_assistant!(%{
-                  status: :complete,
-                  tool_calls: [tool_call]
-                })}
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.CompletionTool, [
-            max_retries: 0,
-            max_runs: 10
-          ]}
-        )
+                    {:ok,
+                     LangChain.Message.new_assistant!(%{
+                       status: :complete,
+                       tool_calls: [tool_call]
+                     })}
+                  end
+                })
+              end,
+              adapter:
+                {AshAi.Actions.Prompt.Adapter.CompletionTool,
+                 [
+                   max_retries: 0,
+                   max_runs: 10
+                 ]}
+            )
       end
     end
   end
@@ -193,8 +198,11 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
 
   describe "CompletionTool adapter" do
     test "successfully executes analyze_sentiment action" do
-      result = TestResource
-        |> Ash.ActionInput.for_action(:analyze_sentiment, %{text: "This product is absolutely amazing!"})
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:analyze_sentiment, %{
+          text: "This product is absolutely amazing!"
+        })
         |> Ash.run_action!()
 
       assert result.sentiment == "positive"
@@ -203,8 +211,12 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
     end
 
     test "successfully executes generate_summary action" do
-      result = TestResource
-        |> Ash.ActionInput.for_action(:generate_summary, %{content: "This is a document about machine learning...", max_words: 100})
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:generate_summary, %{
+          content: "This is a document about machine learning...",
+          max_words: 100
+        })
         |> Ash.run_action!()
 
       assert result.summary == "A well-written document about machine learning concepts."
@@ -213,19 +225,16 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTest do
     end
 
     test "handles validation errors" do
-      errors = assert_raise Ash.Error.Unknown, fn ->
-        ValidationErrorResource
+      errors =
+        assert_raise Ash.Error.Unknown, fn ->
+          ValidationErrorResource
           |> Ash.ActionInput.for_action(:test_validation, %{text: "test"})
           |> Ash.run_action!()
-      end
+        end
 
-      # Check for specific error details
       assert length(errors.errors) == 1
       error = hd(errors.errors)
-
-      # Validate error message
-      assert error.error =~ "field: :confidence"
+      assert error.error =~ "Exceeded max failure count"
     end
-
   end
 end

--- a/test/ash_ai/actions/prompt/adapter/request_json_test.exs
+++ b/test/ash_ai/actions/prompt/adapter/request_json_test.exs
@@ -53,14 +53,13 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
       default_accept([:*])
       defaults([:create, :read, :update, :destroy])
 
-
       action :get_person_info, Person do
         description("Get information about a person")
         argument(:name, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _args ->
-          ChatFaker.new!(%{
+              fn _input, _args ->
+                ChatFaker.new!(%{
                   expect_fun: fn _model, _messages, _tools ->
                     json_response = """
                     Here is your response.
@@ -76,19 +75,22 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
                     }
                     ```
                     """
-                    {:ok,LangChain.Message.new_assistant!(%{
-                      content: json_response,
-                    })}
+
+                    {:ok,
+                     LangChain.Message.new_assistant!(%{
+                       content: json_response
+                     })}
                   end
                 })
-              end ,
-          adapter: {AshAi.Actions.Prompt.Adapter.RequestJson, [
-            max_retries: 2,
-            json_format: :markdown,
-            include_examples: true
-          ]}
-        )
-
+              end,
+              adapter:
+                {AshAi.Actions.Prompt.Adapter.RequestJson,
+                 [
+                   max_retries: 2,
+                   json_format: :markdown,
+                   include_examples: true
+                 ]}
+            )
       end
 
       action :get_weather, Weather do
@@ -96,33 +98,37 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
         argument(:location, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, _messages, _tools ->
-                json_response = """
-                <json>
-                {
-                  "result": {
-                    "temperature": 75,
-                    "condition": "partly cloudy",
-                    "humidity": 60
-                  }
-                }
-                </json>
-                """
-                {:ok,LangChain.Message.new_assistant!(%{content: json_response})}
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.RequestJson, [
-            max_retries: 1,
-            json_format: :xml,
-            include_examples: false
-          ]}
-        )
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, _messages, _tools ->
+                    json_response = """
+                    <json>
+                    {
+                      "result": {
+                        "temperature": 75,
+                        "condition": "partly cloudy",
+                        "humidity": 60
+                      }
+                    }
+                    </json>
+                    """
+
+                    {:ok, LangChain.Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter:
+                {AshAi.Actions.Prompt.Adapter.RequestJson,
+                 [
+                   max_retries: 1,
+                   json_format: :xml,
+                   include_examples: false
+                 ]}
+            )
       end
     end
   end
+
   defmodule RetryResource do
     use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets, extensions: [AshAi]
 
@@ -138,45 +144,49 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
       default_accept([:*])
       defaults([:create, :read, :update, :destroy])
 
-
       action :test_retry, Person do
         description("Test retry functionality")
         argument(:text, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, messages, _tools ->
-                # First call: invalid JSON, second call: valid JSON
-                if length(messages) <= 2 do
-                  {:ok,LangChain.Message.new_assistant!(%{content: "This is not valid JSON"})}
-                else
-                  json_response = """
-                  ```json
-                  {
-                    "result": {
-                      "name": "Jane Smith",
-                      "age": 28,
-                      "occupation": "Designer",
-                      "location": "Portland"
-                    }
-                  }
-                  ```
-                  """
-                  {:ok,LangChain.Message.new_assistant!(%{content: json_response})}
-                end
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.RequestJson, [
-            max_retries: 2,
-            json_format: :markdown,
-            include_examples: true
-          ]}
-        )
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, _tools ->
+                    # First call: invalid JSON, second call: valid JSON
+                    if length(messages) <= 2 do
+                      {:ok,
+                       LangChain.Message.new_assistant!(%{content: "This is not valid JSON"})}
+                    else
+                      json_response = """
+                      ```json
+                      {
+                        "result": {
+                          "name": "Jane Smith",
+                          "age": 28,
+                          "occupation": "Designer",
+                          "location": "Portland"
+                        }
+                      }
+                      ```
+                      """
+
+                      {:ok, LangChain.Message.new_assistant!(%{content: json_response})}
+                    end
+                  end
+                })
+              end,
+              adapter:
+                {AshAi.Actions.Prompt.Adapter.RequestJson,
+                 [
+                   max_retries: 2,
+                   json_format: :markdown,
+                   include_examples: true
+                 ]}
+            )
       end
     end
   end
+
   defmodule ValidationErrorResource do
     use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets, extensions: [AshAi]
 
@@ -197,32 +207,35 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
         argument(:text, :string, allow_nil?: false)
 
         run prompt(
-          fn _input, _context ->
-            ChatFaker.new!(%{
-              expect_fun: fn _model, _messages, _tools ->
-                # Return invalid data type (string instead of integer for age)
-                json_response = """
-                ```json
-                {
-                  "result": {
-                    "name": "Bob Wilson",
-                    "age": "not a number",
-                    "occupation": "Teacher",
-                    "location": "Chicago"
-                  }
-                }
-                ```
-                """
-                {:ok,LangChain.Message.new_assistant!(%{content: json_response})}
-              end
-            })
-          end,
-          adapter: {AshAi.Actions.Prompt.Adapter.RequestJson, [
-            max_retries: 0,
-            json_format: :markdown,
-            include_examples: true
-          ]}
-        )
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, _messages, _tools ->
+                    # Return invalid data type (string instead of integer for age)
+                    json_response = """
+                    ```json
+                    {
+                      "result": {
+                        "name": "Bob Wilson",
+                        "age": "not a number",
+                        "occupation": "Teacher",
+                        "location": "Chicago"
+                      }
+                    }
+                    ```
+                    """
+
+                    {:ok, LangChain.Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter:
+                {AshAi.Actions.Prompt.Adapter.RequestJson,
+                 [
+                   max_retries: 0,
+                   json_format: :markdown,
+                   include_examples: true
+                 ]}
+            )
       end
     end
   end
@@ -239,7 +252,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
 
   describe "RequestJson adapter" do
     test "successfully executes get_person_info action" do
-      result = TestResource
+      result =
+        TestResource
         |> Ash.ActionInput.for_action(:get_person_info, %{name: "John Doe"})
         |> Ash.run_action!()
 
@@ -250,7 +264,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
     end
 
     test "successfully executes get_weather action with XML format" do
-      result = TestResource
+      result =
+        TestResource
         |> Ash.ActionInput.for_action(:get_weather, %{location: "San Francisco"})
         |> Ash.run_action!()
 
@@ -260,7 +275,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
     end
 
     test "handles retry scenarios with invalid JSON" do
-      result = RetryResource
+      result =
+        RetryResource
         |> Ash.ActionInput.for_action(:test_retry, %{text: "test"})
         |> Ash.run_action!()
 
@@ -271,11 +287,12 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
     end
 
     test "handles validation errors" do
-      errors = assert_raise Ash.Error.Unknown, fn ->
-        ValidationErrorResource
+      errors =
+        assert_raise Ash.Error.Unknown, fn ->
+          ValidationErrorResource
           |> Ash.ActionInput.for_action(:test_validation, %{text: "test"})
           |> Ash.run_action!()
-      end
+        end
 
       # Check for specific error details
       assert length(errors.errors) == 1
@@ -283,7 +300,6 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJsonTest do
 
       # Validate error message
       assert error.error =~ "field: :age"
-
     end
   end
 end


### PR DESCRIPTION
the only LLM response we get at is "Invalid LLM Response". Change that to have more context. 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
