### PR TITLE
fix(tasks): fix prompt typo

### DIFF
--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -205,7 +205,7 @@ if Code.ensure_loaded?(Igniter) do
           system_prompt =
             LangChain.Message.new_system!(\"""
             Provide a short name for the current conversation.
-            2-8 words, preferring more succint names.
+            2-8 words, preferring more succinct names.
             RESPOND WITH ONLY THE NEW CONVERSATION NAME.
             \""")
 


### PR DESCRIPTION
Fixes a typo in the default `GenerateName` change, when generated by `ash_ai.gen.chat`.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
