### PR TITLE
Support langchain message

### DIFF
--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -159,7 +159,6 @@ defmodule AshAi.Actions.Prompt do
   """
   use Ash.Resource.Actions.Implementation
 
-  alias AshAi.Actions.Prompt.Adapter.Helpers
 
   require Logger
 
@@ -171,12 +170,13 @@ defmodule AshAi.Actions.Prompt do
 
     tools = get_tools(opts, input, context)
 
-    # Extract system_prompt and user_message from prompt processing
-    {_messages, system_prompt, user_message} = get_messages_and_prompts(input, opts, context)
+    # Get messages and legacy prompts
+    {messages, system_prompt, user_message} = get_messages(input, opts, context)
 
     data = %AshAi.Actions.Prompt.Adapter.Data{
       llm: llm,
       input: input,
+      messages: messages,
       system_prompt: system_prompt,
       user_message: user_message,
       json_schema: json_schema,
@@ -283,234 +283,107 @@ defmodule AshAi.Actions.Prompt do
   end
 
   # sobelow_skip ["RCE.EEx"]
-  defp get_messages_and_prompts(input, opts, context) do
-    try do
-      opts
-      |> Keyword.get(:prompt, @prompt_template)
-      |> log_prompt_type()
-      |> process_prompt_option(input, context)
-      |> finalize_prompt_result()
-    rescue
-      error ->
-        Logger.warning("Error in get_messages_and_prompts: #{inspect(error)}")
-        raise error
+  defp get_messages(input, opts, context) do
+    template_vars = %{input: input, context: context}
+    
+    case Keyword.get(opts, :prompt, @prompt_template) do
+      # Format 1: String (EEx template)
+      prompt when is_binary(prompt) ->
+        system_prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
+        messages = [
+          LangChain.Message.new_system!(system_prompt),
+          LangChain.Message.new_user!("Perform the action")
+        ]
+        {messages, system_prompt, "Perform the action"}
+      
+      # Format 2: Tuple {system, user} (EEx templates)
+      {system, user} when is_binary(system) and is_binary(user) ->
+        system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
+        user_message = EEx.eval_string(user, assigns: [input: input, context: context])
+        messages = [
+          LangChain.Message.new_system!(system_prompt),
+          LangChain.Message.new_user!(user_message)
+        ]
+        {messages, system_prompt, user_message}
+      
+      # Format 3: Messages list (LangChain Messages)
+      messages when is_list(messages) ->
+        processed_messages = process_message_templates(messages, template_vars)
+        {system_prompt, user_message} = extract_legacy_prompts(processed_messages)
+        {processed_messages, system_prompt, user_message}
+      
+      # Format 4: Function returning any of the above
+      func when is_function(func, 2) ->
+        result = func.(input, context)
+        get_messages_from_result(result, input, context)
     end
   end
 
-  defp log_prompt_type(prompt_option) do
-    Logger.debug("Processing prompt type: #{get_prompt_type(prompt_option)}")
-    prompt_option
+  defp get_messages_from_result(result, input, context) do
+    case result do
+      prompt when is_binary(prompt) -> 
+        get_messages(input, [prompt: prompt], context)
+      {system, user} when is_binary(system) and is_binary(user) -> 
+        get_messages(input, [prompt: {system, user}], context)
+      messages when is_list(messages) -> 
+        get_messages(input, [prompt: messages], context)
+      _ ->
+        raise ArgumentError, "Function must return string, {system, user} tuple, or list of Messages. Got: #{inspect(result)}"
+    end
   end
 
-  # Handle {system, user} tuple format
-  defp process_prompt_option({system, user}, input, context)
-       when is_binary(system) and is_binary(user) do
-    Logger.debug("Processing {system, user} tuple format")
-
-    {system, user}
-    |> process_eex_templates(input, context)
-    |> tuple_to_messages()
-  end
-
-  # Handle string format
-  defp process_prompt_option(prompt, input, context) when is_binary(prompt) do
-    prompt
-    |> process_string_prompt(input, context)
-    |> tuple_to_messages()
-  end
-
-  # Handle function format
-  defp process_prompt_option(func, input, context) when is_function(func, 2) do
-    with {:ok, result} <- safe_function_call(func, input, context),
-         {:ok, messages} <- validate_function_result(result, input, context) do
-      messages
+  defp process_message_templates(messages, template_vars) do
+    if AshAi.Actions.Prompt.Adapter.Helpers.has_prompt_templates?(messages) do
+      temp_chain = LangChain.Chains.LLMChain.new!(%{llm: create_dummy_llm()})
+      processed_chain = LangChain.Chains.LLMChain.apply_prompt_templates(temp_chain, messages, template_vars)
+      processed_chain.messages
     else
-      {:error, reason} ->
-        Logger.warning("Function processing failed: #{reason}")
-        raise ArgumentError, reason
+      messages
     end
   end
 
-  # Handle message list format
-  defp process_prompt_option(messages, input, context) when is_list(messages) do
-    Logger.debug("Processing list of #{length(messages)} messages")
-    process_messages_with_templates(messages, input, context)
-  end
-
-  # Helper functions for data transformation
-  defp process_eex_templates({system, user}, input, context) do
-    assigns = [input: input, context: context]
-
-    {
-      EEx.eval_string(system, assigns: assigns),
-      EEx.eval_string(user, assigns: assigns)
-    }
-  end
-
-  defp process_string_prompt(prompt, input, context) do
-    assigns = [input: input, context: context]
-    processed_prompt = EEx.eval_string(prompt, assigns: assigns)
-    {processed_prompt, "Perform the action"}
-  end
-
-  defp tuple_to_messages({system, user}) do
-    [
-      LangChain.Message.new_system!(system),
-      LangChain.Message.new_user!(user)
-    ]
-  end
-
-  defp safe_function_call(func, input, context) do
-    try do
-      result = func.(input, context)
-      Logger.debug("Function returned: #{get_prompt_type(result)}")
-      {:ok, result}
-    rescue
-      error ->
-        {:error, "Function execution failed: #{inspect(error)}"}
-    end
-  end
-
-  defp validate_function_result({system, user}, _input, _context)
-       when is_binary(system) and is_binary(user) do
-    Logger.debug("Function returned {system, user} tuple")
-    messages = tuple_to_messages({system, user})
-    {:ok, messages}
-  end
-
-  defp validate_function_result(messages, input, context) when is_list(messages) do
-    Logger.debug("Function returned list of #{length(messages)} messages")
-    processed_messages = process_messages_with_templates(messages, input, context)
-    {:ok, processed_messages}
-  end
-
-  defp validate_function_result(other, _input, _context) do
-    error =
-      "Function must return either {system, user} tuple or list of LangChain Messages. " <>
-        "Examples: {\"system_message\", \"user_message\"} or " <>
-        "[Message.new_system!(\"Hello\"), Message.new_user!(\"Hi\")]. " <>
-        "Got: #{inspect(other)}"
-
-    {:error, error}
-  end
-
-  defp finalize_prompt_result(messages) when is_list(messages) do
-    {system_prompt, user_message} = extract_legacy_prompts(messages)
-
-    Logger.debug(
-      "Extracted legacy prompts - system: #{String.length(system_prompt)} chars, user: #{String.length(user_message)} chars"
-    )
-
-    {messages, system_prompt, user_message}
+  defp create_dummy_llm do
+    LangChain.ChatModels.ChatOpenAI.new!(%{model: "gpt-3.5-turbo"})
   end
 
   defp extract_legacy_prompts(messages) do
-    system_prompt =
+    system_prompt = 
       case Enum.find(messages, &(&1.role == :system)) do
         %LangChain.Message{content: content} when is_binary(content) -> content
+        %LangChain.Message{content: content} when is_list(content) -> extract_text_content(content)
         _ -> ""
       end
 
-    user_message =
+    user_message = 
       case Enum.find(messages, &(&1.role == :user)) do
-        %LangChain.Message{content: content} when is_binary(content) ->
-          content
-
-        %LangChain.Message{content: content} when is_list(content) ->
-          # Extract only text content parts, safely handling PromptTemplates and other types
-          content
-          |> Enum.filter(fn part ->
-            case part do
-              %LangChain.Message.ContentPart{type: :text} -> true
-              # Include PromptTemplates for legacy extraction
-              %LangChain.PromptTemplate{} -> true
-              _ -> false
-            end
-          end)
-          |> Enum.map(fn
-            %LangChain.Message.ContentPart{type: :text, content: text_content} ->
-              # Only process text content parts, ensuring content is actually text
-              if is_binary(text_content) and String.valid?(text_content),
-                do: text_content,
-                else: ""
-
-            %LangChain.PromptTemplate{text: text} ->
-              # For legacy extraction, just use the raw template text (don't process it)
-              if is_binary(text) and String.valid?(text), do: text, else: ""
-
-            _ ->
-              ""
-          end)
-          |> Enum.join(" ")
-
-        _ ->
-          ""
+        %LangChain.Message{content: content} when is_binary(content) -> content
+        %LangChain.Message{content: content} when is_list(content) -> 
+          text = extract_text_content(content)
+          if text == "", do: "Process the provided content", else: text
+        _ -> "Process the provided content"
       end
 
     {system_prompt, user_message}
   end
 
-  defp process_messages_with_templates(messages, input, context) do
-    case Helpers.has_prompt_templates?(messages) do
-      true ->
-        Logger.debug("Processing PromptTemplates using LangChain")
-        apply_prompt_templates(messages, input, context)
-
-      false ->
-        Logger.debug("No templates to process, returning messages as-is")
-        messages
-    end
-  end
-
-  defp apply_prompt_templates(messages, input, context) do
-    template_vars =
-      %{input: input, context: context}
-      |> Helpers.build_template_variables()
-
-    Logger.debug("Template variables: #{inspect(Map.keys(template_vars))}")
-    Logger.debug("Messages before template processing: #{length(messages)}")
-
-    try do
-      with {:ok, temp_chain} <- create_temp_chain() do
-        # apply_prompt_templates returns the chain directly, not {:ok, chain}
-        processed_chain =
-          LangChain.Chains.LLMChain.apply_prompt_templates(temp_chain, messages, template_vars)
-
-        Logger.debug(
-          "Template processing successful, extracted #{length(processed_chain.messages)} messages"
-        )
-
-        processed_chain.messages
-      else
-        {:error, error} ->
-          Logger.warning("Failed to create temp chain: #{inspect(error)}")
-          raise ArgumentError, "Template processing failed: #{inspect(error)}"
+  defp extract_text_content(content) when is_list(content) do
+    content
+    |> Enum.filter(fn part ->
+      case part do
+        %LangChain.Message.ContentPart{type: :text} -> true
+        _ -> false
       end
-    rescue
-      error ->
-        Logger.warning("Template processing failed: #{inspect(error)}")
-        raise ArgumentError, "Template processing failed: #{inspect(error)}"
-    end
+    end)
+    |> Enum.map(fn
+      %LangChain.Message.ContentPart{type: :text, content: text_content} ->
+        if is_binary(text_content) and String.valid?(text_content),
+          do: text_content,
+          else: ""
+      _ ->
+        ""
+    end)
+    |> Enum.join(" ")
+    |> String.trim()
   end
 
-  defp create_temp_chain do
-    try do
-      # Create a minimal dummy LLM for template processing only
-      dummy_llm = LangChain.ChatModels.ChatOpenAI.new!(%{model: "gpt-3.5-turbo"})
-      chain = LangChain.Chains.LLMChain.new!(%{llm: dummy_llm})
-      {:ok, chain}
-    rescue
-      error -> {:error, error}
-    end
-  end
-
-  defp get_prompt_type(prompt) do
-    cond do
-      is_binary(prompt) -> :string
-      is_function(prompt, 2) -> :function
-      is_list(prompt) -> :message_list
-      match?({_, _}, prompt) -> :tuple
-      true -> :unknown
-    end
-  end
 end

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -57,22 +57,7 @@ defmodule AshAi.Actions.Prompt do
   The first argument to `prompt/2` is the `LangChain` model. It can also be a 2-arity function which will be invoked
   with the input and the context, useful for dynamically selecting the model.
 
-  ## Dynamic Configuration (using 2-arity function)
 
-  For runtime configuration (like using environment variables), pass a function
-  as the first argument to `prompt/2`:
-
-      run prompt(
-        fn _input, _context ->
-          LangChain.ChatModels.ChatOpenAI.new!(%{
-            model: "gpt-4o",
-            # this can also be configured in application config, see langchain docs for more.
-            api_key: System.get_env("OPENAI_API_KEY"),
-            endpoint: System.get_env("OPENAI_ENDPOINT")
-          })
-        end,
-        tools: false
-      )
 
   This function will be executed just before the prompt is sent to the LLM.
 
@@ -80,25 +65,91 @@ defmodule AshAi.Actions.Prompt do
 
   - `:tools`: A list of tool names to expose to the agent call.
   - `:verbose?`: Set to `true` for more output to be logged.
-  - `:prompt`: A custom prompt as an `EEx` template. See the prompt section below.
+  - `:prompt`: A custom prompt. Supports multiple formats - see the prompt section below.
 
   ## Prompt
 
   The prompt by default is generated using the action and input descriptions. You can provide your own prompt
-  via the `prompt` option which will be able to reference `@input` and `@context`.
+  via the `prompt` option which supports multiple formats based on the type of data provided:
 
-  The prompt can be a string or a tuple of two strings. The first string is the system prompt and the second string is the user message.
-  If no user message is provided, the user message will be "perform the action". Both are treated as EEx templates.
+  ### Supported Formats
 
-  We have found that the "3rd party" style description writing paired with the format we provide by default to be
-  a good basis point for LLMs who are meant to accomplish a task. With this in mind, for refining your prompt,
-  first try describing via the action description that desired outcome or operating basis of the action, as well
-  as how the LLM is meant to use them. State these passively as facts. For example, above we used: "Does not consider swear
-  words as inherently negative" instead of instructing the LLM via "Do not consider swear words as inherently negative".
+  1. **String (EEx template)**: `"Analyze this: <%= @input.arguments.text %>"`
+  2. **{System, User} tuple**: `{"You are an expert", "Analyze the sentiment"}`
+  3. **Function**: `fn input, context -> {"Dynamic system", "Dynamic user"} end`
+  4. **List of LangChain Messages**: `[Message.new_system!("..."), Message.new_user!("...")]`
+  5. **Function returning Messages**: `fn input, context -> [Message.new_system!("...")] end`
 
-  You are of course free to use any prompting pattern you prefer, but the end result of the above prompting pattern
-  leads to having a great description of your actual logic, acting both as documentation and instructions to the
-  LLM that executes the action.
+  ### Examples
+
+  #### Basic String Template
+  ```elixir
+  run prompt(
+    ChatOpenAI.new!(%{model: "gpt-4o"}),
+    prompt: "Analyze the sentiment of: <%= @input.arguments.text %>"
+  )
+  ```
+
+  #### System/User Tuple
+  ```elixir
+  run prompt(
+    ChatOpenAI.new!(%{model: "gpt-4o"}),
+    prompt: {"You are a sentiment analyzer", "Analyze: <%= @input.arguments.text %>"}
+  )
+  ```
+
+  #### LangChain Messages for Multi-turn Conversations
+  ```elixir
+  run prompt(
+    ChatOpenAI.new!(%{model: "gpt-4o"}),
+    prompt: [
+      Message.new_system!("You are an expert assistant"),
+      Message.new_user!("Hello, how can you help me?"),
+      Message.new_assistant!("I can help with various tasks"),
+      Message.new_user!("Great! Please analyze this data")
+    ]
+  )
+  ```
+
+  #### Image Analysis with Templates
+  ```elixir
+  run prompt(
+    ChatOpenAI.new!(%{model: "gpt-4o"}),
+    prompt: [
+      Message.new_system!("You are an expert at image analysis"),
+      Message.new_user!([
+        PromptTemplate.from_template!("Extra context: <%= @input.arguments.context %>"),
+        ContentPart.image!("<%= @input.arguments.image_data %>", media: :jpg, detail: "low")
+      ])
+    ]
+  )
+  ```
+
+  #### Dynamic Messages via Function
+  ```elixir
+  run prompt(
+    ChatOpenAI.new!(%{model: "gpt-4o"}),
+    prompt: fn input, context ->
+      base = [Message.new_system!("You are helpful")]
+
+      history = input.arguments.conversation_history
+      |> Enum.map(fn %{"role" => role, "content" => content} ->
+        case role do
+          "user" -> Message.new_user!(content)
+          "assistant" -> Message.new_assistant!(content)
+        end
+      end)
+
+      base ++ history
+    end
+  )
+  ```
+
+  ### Template Processing
+
+  - **String prompts**: Processed as EEx templates with `@input` and `@context`
+  - **Messages with PromptTemplate**: Processed using LangChain's `apply_prompt_templates`
+  - **Functions**: Can return any supported format for dynamic generation
 
   The default prompt template is:
 
@@ -108,12 +159,20 @@ defmodule AshAi.Actions.Prompt do
   """
   use Ash.Resource.Actions.Implementation
 
+  alias AshAi.Actions.Prompt.Adapter.Helpers
+
+  require Logger
+
   def run(input, opts, context) do
     llm = get_llm(opts, input, context)
+
     json_schema = get_json_schema(input)
     {adapter, adapter_opts} = get_adapter(opts, llm)
-    {system_prompt, user_message} = get_prompts(input, opts, context)
+
     tools = get_tools(opts, input, context)
+
+    # Extract system_prompt and user_message from prompt processing
+    {_messages, system_prompt, user_message} = get_messages_and_prompts(input, opts, context)
 
     data = %AshAi.Actions.Prompt.Adapter.Data{
       llm: llm,
@@ -202,6 +261,7 @@ defmodule AshAi.Actions.Prompt do
             AshAi.Actions.Prompt.Adapter.StructuredOutput
 
           %LangChain.ChatModels.ChatOpenAI{endpoint: endpoint} when not is_nil(endpoint) ->
+            # For non-OpenAI endpoints, use RequestJson
             AshAi.Actions.Prompt.Adapter.RequestJson
 
           %LangChain.ChatModels.ChatAnthropic{} ->
@@ -223,19 +283,234 @@ defmodule AshAi.Actions.Prompt do
   end
 
   # sobelow_skip ["RCE.EEx"]
-  defp get_prompts(input, opts, context) do
-    case Keyword.get(opts, :prompt, @prompt_template) do
-      {prompt, user_message} ->
-        prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
+  defp get_messages_and_prompts(input, opts, context) do
+    try do
+      opts
+      |> Keyword.get(:prompt, @prompt_template)
+      |> log_prompt_type()
+      |> process_prompt_option(input, context)
+      |> finalize_prompt_result()
+    rescue
+      error ->
+        Logger.warning("Error in get_messages_and_prompts: #{inspect(error)}")
+        raise error
+    end
+  end
 
-        user_message =
-          EEx.eval_string(user_message, assigns: [input: input, context: context])
+  defp log_prompt_type(prompt_option) do
+    Logger.debug("Processing prompt type: #{get_prompt_type(prompt_option)}")
+    prompt_option
+  end
 
-        {prompt, user_message}
+  # Handle {system, user} tuple format
+  defp process_prompt_option({system, user}, input, context)
+       when is_binary(system) and is_binary(user) do
+    Logger.debug("Processing {system, user} tuple format")
 
-      prompt ->
-        prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
-        {prompt, "Perform the action"}
+    {system, user}
+    |> process_eex_templates(input, context)
+    |> tuple_to_messages()
+  end
+
+  # Handle string format
+  defp process_prompt_option(prompt, input, context) when is_binary(prompt) do
+    prompt
+    |> process_string_prompt(input, context)
+    |> tuple_to_messages()
+  end
+
+  # Handle function format
+  defp process_prompt_option(func, input, context) when is_function(func, 2) do
+    with {:ok, result} <- safe_function_call(func, input, context),
+         {:ok, messages} <- validate_function_result(result, input, context) do
+      messages
+    else
+      {:error, reason} ->
+        Logger.warning("Function processing failed: #{reason}")
+        raise ArgumentError, reason
+    end
+  end
+
+  # Handle message list format
+  defp process_prompt_option(messages, input, context) when is_list(messages) do
+    Logger.debug("Processing list of #{length(messages)} messages")
+    process_messages_with_templates(messages, input, context)
+  end
+
+  # Helper functions for data transformation
+  defp process_eex_templates({system, user}, input, context) do
+    assigns = [input: input, context: context]
+
+    {
+      EEx.eval_string(system, assigns: assigns),
+      EEx.eval_string(user, assigns: assigns)
+    }
+  end
+
+  defp process_string_prompt(prompt, input, context) do
+    assigns = [input: input, context: context]
+    processed_prompt = EEx.eval_string(prompt, assigns: assigns)
+    {processed_prompt, "Perform the action"}
+  end
+
+  defp tuple_to_messages({system, user}) do
+    [
+      LangChain.Message.new_system!(system),
+      LangChain.Message.new_user!(user)
+    ]
+  end
+
+  defp safe_function_call(func, input, context) do
+    try do
+      result = func.(input, context)
+      Logger.debug("Function returned: #{get_prompt_type(result)}")
+      {:ok, result}
+    rescue
+      error ->
+        {:error, "Function execution failed: #{inspect(error)}"}
+    end
+  end
+
+  defp validate_function_result({system, user}, _input, _context)
+       when is_binary(system) and is_binary(user) do
+    Logger.debug("Function returned {system, user} tuple")
+    messages = tuple_to_messages({system, user})
+    {:ok, messages}
+  end
+
+  defp validate_function_result(messages, input, context) when is_list(messages) do
+    Logger.debug("Function returned list of #{length(messages)} messages")
+    processed_messages = process_messages_with_templates(messages, input, context)
+    {:ok, processed_messages}
+  end
+
+  defp validate_function_result(other, _input, _context) do
+    error =
+      "Function must return either {system, user} tuple or list of LangChain Messages. " <>
+        "Examples: {\"system_message\", \"user_message\"} or " <>
+        "[Message.new_system!(\"Hello\"), Message.new_user!(\"Hi\")]. " <>
+        "Got: #{inspect(other)}"
+
+    {:error, error}
+  end
+
+  defp finalize_prompt_result(messages) when is_list(messages) do
+    {system_prompt, user_message} = extract_legacy_prompts(messages)
+
+    Logger.debug(
+      "Extracted legacy prompts - system: #{String.length(system_prompt)} chars, user: #{String.length(user_message)} chars"
+    )
+
+    {messages, system_prompt, user_message}
+  end
+
+  defp extract_legacy_prompts(messages) do
+    system_prompt =
+      case Enum.find(messages, &(&1.role == :system)) do
+        %LangChain.Message{content: content} when is_binary(content) -> content
+        _ -> ""
+      end
+
+    user_message =
+      case Enum.find(messages, &(&1.role == :user)) do
+        %LangChain.Message{content: content} when is_binary(content) ->
+          content
+
+        %LangChain.Message{content: content} when is_list(content) ->
+          # Extract only text content parts, safely handling PromptTemplates and other types
+          content
+          |> Enum.filter(fn part ->
+            case part do
+              %LangChain.Message.ContentPart{type: :text} -> true
+              # Include PromptTemplates for legacy extraction
+              %LangChain.PromptTemplate{} -> true
+              _ -> false
+            end
+          end)
+          |> Enum.map(fn
+            %LangChain.Message.ContentPart{type: :text, content: text_content} ->
+              # Only process text content parts, ensuring content is actually text
+              if is_binary(text_content) and String.valid?(text_content),
+                do: text_content,
+                else: ""
+
+            %LangChain.PromptTemplate{text: text} ->
+              # For legacy extraction, just use the raw template text (don't process it)
+              if is_binary(text) and String.valid?(text), do: text, else: ""
+
+            _ ->
+              ""
+          end)
+          |> Enum.join(" ")
+
+        _ ->
+          ""
+      end
+
+    {system_prompt, user_message}
+  end
+
+  defp process_messages_with_templates(messages, input, context) do
+    case Helpers.has_prompt_templates?(messages) do
+      true ->
+        Logger.debug("Processing PromptTemplates using LangChain")
+        apply_prompt_templates(messages, input, context)
+
+      false ->
+        Logger.debug("No templates to process, returning messages as-is")
+        messages
+    end
+  end
+
+  defp apply_prompt_templates(messages, input, context) do
+    template_vars =
+      %{input: input, context: context}
+      |> Helpers.build_template_variables()
+
+    Logger.debug("Template variables: #{inspect(Map.keys(template_vars))}")
+    Logger.debug("Messages before template processing: #{length(messages)}")
+
+    try do
+      with {:ok, temp_chain} <- create_temp_chain() do
+        # apply_prompt_templates returns the chain directly, not {:ok, chain}
+        processed_chain =
+          LangChain.Chains.LLMChain.apply_prompt_templates(temp_chain, messages, template_vars)
+
+        Logger.debug(
+          "Template processing successful, extracted #{length(processed_chain.messages)} messages"
+        )
+
+        processed_chain.messages
+      else
+        {:error, error} ->
+          Logger.warning("Failed to create temp chain: #{inspect(error)}")
+          raise ArgumentError, "Template processing failed: #{inspect(error)}"
+      end
+    rescue
+      error ->
+        Logger.warning("Template processing failed: #{inspect(error)}")
+        raise ArgumentError, "Template processing failed: #{inspect(error)}"
+    end
+  end
+
+  defp create_temp_chain do
+    try do
+      # Create a minimal dummy LLM for template processing only
+      dummy_llm = LangChain.ChatModels.ChatOpenAI.new!(%{model: "gpt-3.5-turbo"})
+      chain = LangChain.Chains.LLMChain.new!(%{llm: dummy_llm})
+      {:ok, chain}
+    rescue
+      error -> {:error, error}
+    end
+  end
+
+  defp get_prompt_type(prompt) do
+    cond do
+      is_binary(prompt) -> :string
+      is_function(prompt, 2) -> :function
+      is_list(prompt) -> :message_list
+      match?({_, _}, prompt) -> :tuple
+      true -> :unknown
     end
   end
 end

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -181,15 +181,12 @@ defmodule AshAi.Actions.Prompt do
 
     tools = get_tools(opts, input, context)
 
-    # Get messages and legacy prompts
-    {messages, system_prompt, user_message} = get_messages(input, opts, context)
+    messages = get_messages(input, opts, context)
 
     data = %AshAi.Actions.Prompt.Adapter.Data{
       llm: llm,
       input: input,
       messages: messages,
-      system_prompt: system_prompt,
-      user_message: user_message,
       json_schema: json_schema,
       tools: tools,
       verbose?: opts[:verbose?] || false,
@@ -302,30 +299,24 @@ defmodule AshAi.Actions.Prompt do
       prompt when is_binary(prompt) ->
         system_prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
 
-        messages = [
+        [
           LangChain.Message.new_system!(system_prompt),
           LangChain.Message.new_user!("Perform the action")
         ]
-
-        {messages, system_prompt, "Perform the action"}
 
       # Format 2: Tuple {system, user} (EEx templates)
       {system, user} when is_binary(system) and is_binary(user) ->
         system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
         user_message = EEx.eval_string(user, assigns: [input: input, context: context])
 
-        messages = [
+        [
           LangChain.Message.new_system!(system_prompt),
           LangChain.Message.new_user!(user_message)
         ]
 
-        {messages, system_prompt, user_message}
-
       # Format 3: Messages list (LangChain Messages)
       messages when is_list(messages) ->
-        processed_messages = process_message_templates(messages, template_vars)
-        {system_prompt, user_message} = extract_legacy_prompts(processed_messages)
-        {processed_messages, system_prompt, user_message}
+        process_message_templates(messages, template_vars)
 
       # Format 4: Function returning any of the above
       func when is_function(func, 2) ->
@@ -366,54 +357,5 @@ defmodule AshAi.Actions.Prompt do
 
   defp create_dummy_llm do
     LangChain.ChatModels.ChatOpenAI.new!(%{model: "gpt-3.5-turbo"})
-  end
-
-  defp extract_legacy_prompts(messages) do
-    system_prompt =
-      case Enum.find(messages, &(&1.role == :system)) do
-        %LangChain.Message{content: content} when is_binary(content) ->
-          content
-
-        %LangChain.Message{content: content} when is_list(content) ->
-          extract_text_content(content)
-
-        _ ->
-          ""
-      end
-
-    user_message =
-      case Enum.find(messages, &(&1.role == :user)) do
-        %LangChain.Message{content: content} when is_binary(content) ->
-          content
-
-        %LangChain.Message{content: content} when is_list(content) ->
-          text = extract_text_content(content)
-          if text == "", do: "Process the provided content", else: text
-
-        _ ->
-          "Process the provided content"
-      end
-
-    {system_prompt, user_message}
-  end
-
-  defp extract_text_content(content) when is_list(content) do
-    content
-    |> Enum.filter(fn part ->
-      case part do
-        %LangChain.Message.ContentPart{type: :text} -> true
-        _ -> false
-      end
-    end)
-    |> Enum.map_join(" ", fn
-      %LangChain.Message.ContentPart{type: :text, content: text_content} ->
-        if is_binary(text_content) and String.valid?(text_content),
-          do: text_content,
-          else: ""
-
-      _ ->
-        ""
-    end)
-    |> String.trim()
   end
 end

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -174,8 +174,6 @@ defmodule AshAi.Actions.Prompt do
   use Ash.Resource.Actions.Implementation
 
 
-  require Logger
-
   def run(input, opts, context) do
     llm = get_llm(opts, input, context)
 

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -173,7 +173,6 @@ defmodule AshAi.Actions.Prompt do
   """
   use Ash.Resource.Actions.Implementation
 
-
   def run(input, opts, context) do
     llm = get_llm(opts, input, context)
 
@@ -302,20 +301,24 @@ defmodule AshAi.Actions.Prompt do
       # Format 1: String (EEx template)
       prompt when is_binary(prompt) ->
         system_prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
+
         messages = [
           LangChain.Message.new_system!(system_prompt),
           LangChain.Message.new_user!("Perform the action")
         ]
+
         {messages, system_prompt, "Perform the action"}
 
       # Format 2: Tuple {system, user} (EEx templates)
       {system, user} when is_binary(system) and is_binary(user) ->
         system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
         user_message = EEx.eval_string(user, assigns: [input: input, context: context])
+
         messages = [
           LangChain.Message.new_system!(system_prompt),
           LangChain.Message.new_user!(user_message)
         ]
+
         {messages, system_prompt, user_message}
 
       # Format 3: Messages list (LangChain Messages)
@@ -335,19 +338,26 @@ defmodule AshAi.Actions.Prompt do
     case result do
       prompt when is_binary(prompt) ->
         get_messages(input, [prompt: prompt], context)
+
       {system, user} when is_binary(system) and is_binary(user) ->
         get_messages(input, [prompt: {system, user}], context)
+
       messages when is_list(messages) ->
         get_messages(input, [prompt: messages], context)
+
       _ ->
-        raise ArgumentError, "Function must return string, {system, user} tuple, or list of Messages. Got: #{inspect(result)}"
+        raise ArgumentError,
+              "Function must return string, {system, user} tuple, or list of Messages. Got: #{inspect(result)}"
     end
   end
 
   defp process_message_templates(messages, template_vars) do
     if AshAi.Actions.Prompt.Adapter.Helpers.has_prompt_templates?(messages) do
       temp_chain = LangChain.Chains.LLMChain.new!(%{llm: create_dummy_llm()})
-      processed_chain = LangChain.Chains.LLMChain.apply_prompt_templates(temp_chain, messages, template_vars)
+
+      processed_chain =
+        LangChain.Chains.LLMChain.apply_prompt_templates(temp_chain, messages, template_vars)
+
       processed_chain.messages
     else
       messages
@@ -361,18 +371,27 @@ defmodule AshAi.Actions.Prompt do
   defp extract_legacy_prompts(messages) do
     system_prompt =
       case Enum.find(messages, &(&1.role == :system)) do
-        %LangChain.Message{content: content} when is_binary(content) -> content
-        %LangChain.Message{content: content} when is_list(content) -> extract_text_content(content)
-        _ -> ""
+        %LangChain.Message{content: content} when is_binary(content) ->
+          content
+
+        %LangChain.Message{content: content} when is_list(content) ->
+          extract_text_content(content)
+
+        _ ->
+          ""
       end
 
     user_message =
       case Enum.find(messages, &(&1.role == :user)) do
-        %LangChain.Message{content: content} when is_binary(content) -> content
+        %LangChain.Message{content: content} when is_binary(content) ->
+          content
+
         %LangChain.Message{content: content} when is_list(content) ->
           text = extract_text_content(content)
           if text == "", do: "Process the provided content", else: text
-        _ -> "Process the provided content"
+
+        _ ->
+          "Process the provided content"
       end
 
     {system_prompt, user_message}
@@ -386,16 +405,15 @@ defmodule AshAi.Actions.Prompt do
         _ -> false
       end
     end)
-    |> Enum.map(fn
+    |> Enum.map_join(" ", fn
       %LangChain.Message.ContentPart{type: :text, content: text_content} ->
         if is_binary(text_content) and String.valid?(text_content),
           do: text_content,
           else: ""
+
       _ ->
         ""
     end)
-    |> Enum.join(" ")
     |> String.trim()
   end
-
 end

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -57,6 +57,20 @@ defmodule AshAi.Actions.Prompt do
   The first argument to `prompt/2` is the `LangChain` model. It can also be a 2-arity function which will be invoked
   with the input and the context, useful for dynamically selecting the model.
 
+  ## Dynamic Configuration (using 2-arity function)
+  For runtime configuration (like using environment variables), pass a function
+  as the first argument to `prompt/2`:
+      run prompt(
+        fn _input, _context ->
+          LangChain.ChatModels.ChatOpenAI.new!(%{
+            model: "gpt-4o",
+            # this can also be configured in application config, see langchain docs for more.
+            api_key: System.get_env("OPENAI_API_KEY"),
+            endpoint: System.get_env("OPENAI_ENDPOINT")
+          })
+        end,
+        tools: false
+      )
 
 
   This function will be executed just before the prompt is sent to the LLM.
@@ -285,7 +299,7 @@ defmodule AshAi.Actions.Prompt do
   # sobelow_skip ["RCE.EEx"]
   defp get_messages(input, opts, context) do
     template_vars = %{input: input, context: context}
-    
+
     case Keyword.get(opts, :prompt, @prompt_template) do
       # Format 1: String (EEx template)
       prompt when is_binary(prompt) ->
@@ -295,7 +309,7 @@ defmodule AshAi.Actions.Prompt do
           LangChain.Message.new_user!("Perform the action")
         ]
         {messages, system_prompt, "Perform the action"}
-      
+
       # Format 2: Tuple {system, user} (EEx templates)
       {system, user} when is_binary(system) and is_binary(user) ->
         system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
@@ -305,13 +319,13 @@ defmodule AshAi.Actions.Prompt do
           LangChain.Message.new_user!(user_message)
         ]
         {messages, system_prompt, user_message}
-      
+
       # Format 3: Messages list (LangChain Messages)
       messages when is_list(messages) ->
         processed_messages = process_message_templates(messages, template_vars)
         {system_prompt, user_message} = extract_legacy_prompts(processed_messages)
         {processed_messages, system_prompt, user_message}
-      
+
       # Format 4: Function returning any of the above
       func when is_function(func, 2) ->
         result = func.(input, context)
@@ -321,11 +335,11 @@ defmodule AshAi.Actions.Prompt do
 
   defp get_messages_from_result(result, input, context) do
     case result do
-      prompt when is_binary(prompt) -> 
+      prompt when is_binary(prompt) ->
         get_messages(input, [prompt: prompt], context)
-      {system, user} when is_binary(system) and is_binary(user) -> 
+      {system, user} when is_binary(system) and is_binary(user) ->
         get_messages(input, [prompt: {system, user}], context)
-      messages when is_list(messages) -> 
+      messages when is_list(messages) ->
         get_messages(input, [prompt: messages], context)
       _ ->
         raise ArgumentError, "Function must return string, {system, user} tuple, or list of Messages. Got: #{inspect(result)}"
@@ -347,17 +361,17 @@ defmodule AshAi.Actions.Prompt do
   end
 
   defp extract_legacy_prompts(messages) do
-    system_prompt = 
+    system_prompt =
       case Enum.find(messages, &(&1.role == :system)) do
         %LangChain.Message{content: content} when is_binary(content) -> content
         %LangChain.Message{content: content} when is_list(content) -> extract_text_content(content)
         _ -> ""
       end
 
-    user_message = 
+    user_message =
       case Enum.find(messages, &(&1.role == :user)) do
         %LangChain.Message{content: content} when is_binary(content) -> content
-        %LangChain.Message{content: content} when is_list(content) -> 
+        %LangChain.Message{content: content} when is_list(content) ->
           text = extract_text_content(content)
           if text == "", do: "Process the provided content", else: text
         _ -> "Process the provided content"

--- a/lib/ash_ai/actions/prompt/adapter.ex
+++ b/lib/ash_ai/actions/prompt/adapter.ex
@@ -36,9 +36,7 @@ defmodule AshAi.Actions.Prompt.Adapter do
       :llm,
       :input,
       :messages,
-      :system_prompt,
       :verbose?,
-      :user_message,
       :json_schema,
       :tools,
       :context
@@ -48,8 +46,6 @@ defmodule AshAi.Actions.Prompt.Adapter do
             llm: term(),
             input: Ash.ActionInput.t(),
             messages: list(),
-            system_prompt: String.t(),
-            user_message: String.t(),
             json_schema: map(),
             tools: list(),
             verbose?: boolean(),

--- a/lib/ash_ai/actions/prompt/adapter.ex
+++ b/lib/ash_ai/actions/prompt/adapter.ex
@@ -35,6 +35,7 @@ defmodule AshAi.Actions.Prompt.Adapter do
     defstruct [
       :llm,
       :input,
+      :messages,
       :system_prompt,
       :verbose?,
       :user_message,
@@ -46,6 +47,7 @@ defmodule AshAi.Actions.Prompt.Adapter do
     @type t :: %__MODULE__{
             llm: term(),
             input: Ash.ActionInput.t(),
+            messages: list(),
             system_prompt: String.t(),
             user_message: String.t(),
             json_schema: map(),

--- a/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
+++ b/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
@@ -18,15 +18,16 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
 
   def run(%Data{} = data, opts) do
     # Use messages directly if available, fallback to legacy prompts
-    messages = if data.messages do
-      data.messages
-    else
-      # Legacy fallback
-      [
-        [ContentPart.text!(data.system_prompt, cache_control: true)] |> Message.new_system!(),
-        Message.new_user!(data.user_message)
-      ]
-    end
+    messages =
+      if data.messages do
+        data.messages
+      else
+        # Legacy fallback
+        [
+          [ContentPart.text!(data.system_prompt, cache_control: true)] |> Message.new_system!(),
+          Message.new_user!(data.user_message)
+        ]
+      end
 
     max_runs = opts[:max_runs] || 25
 

--- a/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
+++ b/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
@@ -12,16 +12,21 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
   @dialyzer {:nowarn_function, [run: 2]}
 
   alias AshAi.Actions.Prompt.Adapter.Data
-  alias AshAi.Actions.Prompt.Adapter.Helpers
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
   alias LangChain.Message.ContentPart
 
   def run(%Data{} = data, opts) do
-    messages = [
-      [ContentPart.text!(data.system_prompt, cache_control: true)] |> Message.new_system!(),
-      Message.new_user!(data.user_message)
-    ]
+    # Use messages directly if available, fallback to legacy prompts
+    messages = if data.messages do
+      data.messages
+    else
+      # Legacy fallback
+      [
+        [ContentPart.text!(data.system_prompt, cache_control: true)] |> Message.new_system!(),
+        Message.new_user!(data.user_message)
+      ]
+    end
 
     max_runs = opts[:max_runs] || 25
 
@@ -85,7 +90,7 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
       custom_context: Map.new(Ash.Context.to_opts(data.context))
     }
     |> LLMChain.new!()
-    |> LLMChain.add_messages(messages)
+    |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools([completion_tool | data.tools])
     |> LLMChain.run_until_tool_used("complete_request", max_runs: max_runs)
     |> case do

--- a/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
+++ b/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
@@ -13,21 +13,9 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
-  alias LangChain.Message
-  alias LangChain.Message.ContentPart
 
   def run(%Data{} = data, opts) do
-    # Use messages directly if available, fallback to legacy prompts
-    messages =
-      if data.messages do
-        data.messages
-      else
-        # Legacy fallback
-        [
-          [ContentPart.text!(data.system_prompt, cache_control: true)] |> Message.new_system!(),
-          Message.new_user!(data.user_message)
-        ]
-      end
+    messages = data.messages
 
     max_runs = opts[:max_runs] || 25
 

--- a/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
+++ b/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
@@ -12,6 +12,7 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
   @dialyzer {:nowarn_function, [run: 2]}
 
   alias AshAi.Actions.Prompt.Adapter.Data
+  alias AshAi.Actions.Prompt.Adapter.Helpers
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
   alias LangChain.Message.ContentPart

--- a/lib/ash_ai/actions/prompt/adapter/helpers.ex
+++ b/lib/ash_ai/actions/prompt/adapter/helpers.ex
@@ -1,6 +1,25 @@
 defmodule AshAi.Actions.Prompt.Adapter.Helpers do
   @moduledoc """
-  Shared helper functions for prompt adapters.
+  Helpers for processing `LangChain.PromptTemplate`s in messages.
+
+  This module resolves templates with runtime data from the action's input
+  and context before the prompt is sent to an LLM.
+
+  ### Example
+
+  Given a prompt with a template:
+
+  ```elixir
+  messages = [
+    Message.new_user!([
+      PromptTemplate.from_template!("Context: <%= @input.arguments.extra_info %>"),
+      ContentPart.text!("Analyze the following text.")
+    ])
+  ]
+  ```
+
+  Adapters use `add_messages_with_templates/3` to resolve such templates,
+  injecting variables from the action input and context.
   """
 
   alias LangChain.Chains.LLMChain

--- a/lib/ash_ai/actions/prompt/adapter/helpers.ex
+++ b/lib/ash_ai/actions/prompt/adapter/helpers.ex
@@ -1,0 +1,61 @@
+defmodule AshAi.Actions.Prompt.Adapter.Helpers do
+  @moduledoc """
+  Shared helper functions for prompt adapters.
+  """
+
+  alias LangChain.Chains.LLMChain
+
+  @doc """
+  Adds messages to a chain, applying prompt templates if any are present.
+
+  This function checks if any messages contain PromptTemplate structs and if so,
+  uses LLMChain.apply_prompt_templates to resolve them with the provided template variables.
+  Otherwise, it adds messages directly to the chain.
+  """
+  def add_messages_with_templates(chain, messages, data) do
+    if has_prompt_templates?(messages) do
+      template_vars = build_template_variables(data)
+      LLMChain.apply_prompt_templates(chain, messages, template_vars)
+    else
+      LLMChain.add_messages(chain, messages)
+    end
+  end
+
+  @doc """
+  Checks if any messages contain PromptTemplate structs in their content.
+  """
+  def has_prompt_templates?(messages) do
+    Enum.any?(messages, fn message ->
+      case message.content do
+        content when is_list(content) ->
+          Enum.any?(content, &match?(%LangChain.PromptTemplate{}, &1))
+
+        _ ->
+          false
+      end
+    end)
+  end
+
+  @doc """
+  Builds template variables from adapter data, including input, context, and action arguments.
+  """
+  def build_template_variables(data) do
+    Map.merge(
+      %{
+        input: data.input,
+        context: data.context
+      },
+      # Extract additional variables that might be passed through arguments
+      extract_template_args(data.input)
+    )
+  end
+
+  defp extract_template_args(%{arguments: args}) when is_map(args) do
+    # Extract common template variables from action arguments
+    args
+    |> Map.take([:extra_image_info, :template_vars, :context_vars])
+    |> Enum.into(%{})
+  end
+
+  defp extract_template_args(_), do: %{}
+end

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -23,13 +23,17 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   alias LangChain.Message
   alias LangChain.MessageProcessors.JsonProcessor
 
+  require Logger
+
   @default_max_retries 2
 
   def run(%Data{} = data, opts) do
+    Logger.debug("RequestJson adapter starting")
     max_retries = opts[:max_retries] || @default_max_retries
     json_format = opts[:json_format] || :markdown
     include_examples = Keyword.get(opts, :include_examples, true)
 
+    # Build enhanced system prompt with JSON schema instructions
     enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
 
     messages = [
@@ -37,31 +41,40 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
       Message.new_user!(data.user_message)
     ]
 
+    Logger.debug("Message processing completed: #{inspect(messages)}")
+
     regex =
       case json_format do
         :xml -> ~r/<json>\s*(.*?)\s*<\/json>/s
         _ -> ~r/```json\s*(.*?)\s*```/s
       end
 
+    Logger.debug("Regex processing completed: #{inspect(regex)}")
+
     json_processor = JsonProcessor.new!(regex)
 
-    chain =
-      %{
-        llm: data.llm,
-        verbose: data.verbose?,
-        custom_context: Map.new(Ash.Context.to_opts(data.context))
-      }
-      |> LLMChain.new!()
-      |> LLMChain.add_messages(messages)
-      |> LLMChain.add_tools(data.tools)
-      |> LLMChain.message_processors([json_processor])
+    Logger.debug("About to create LLMChain")
 
-    run_with_retries(chain, data, max_retries, 0)
+    %{
+      llm: data.llm,
+      verbose: data.verbose?,
+      custom_context: Map.new(Ash.Context.to_opts(data.context))
+    }
+    |> LLMChain.new!()
+    |> LLMChain.add_messages(messages)
+    |> LLMChain.add_tools(data.tools)
+    |> LLMChain.message_processors([json_processor])
+    |> run_with_retries(data, max_retries, 0)
   end
 
   defp run_with_retries(chain, data, max_retries, attempt) do
+    Logger.debug("RequestJson run_with_retries attempt #{attempt}/#{max_retries}")
+    Logger.debug("About to call LLMChain.run")
+
     case LLMChain.run(chain, mode: :while_needs_response) do
       {:ok, %LLMChain{last_message: %Message{role: :assistant} = message} = updated_chain} ->
+        Logger.debug("LLMChain.run succeeded, processing response")
+
         case process_response(message, data, attempt) do
           {:ok, result} ->
             {:ok, result}
@@ -78,17 +91,24 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
         end
 
       {:error, _, error} ->
+        Logger.debug("LLMChain.run failed with error: #{inspect(error)}")
         {:error, error}
+
+      other ->
+        Logger.debug("LLMChain.run returned unexpected result: #{inspect(other)}")
+        {:error, "Unexpected LLMChain result: #{inspect(other)}"}
     end
   end
 
   defp process_response(%Message{processed_content: content}, data, _attempt)
        when is_map(content) do
+    Logger.debug("Processing response with processed_content: #{inspect(content)}")
     # JsonProcessor successfully extracted JSON
     validate_and_cast_result(content, data)
   end
 
   defp process_response(%Message{content: content}, data, _attempt) when is_binary(content) do
+    Logger.debug("Processing response with binary content")
     # Fallback: try to parse raw content as JSON
     case Jason.decode(content) do
       {:ok, decoded} ->
@@ -100,11 +120,13 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     end
   end
 
-  defp process_response(_, _, _) do
+  defp process_response(message, _, _) do
+    Logger.debug("process_response got unexpected message: #{inspect(message)}")
     {:error, "Invalid response format"}
   end
 
   defp validate_and_cast_result(content, data) do
+    Logger.debug("Validating and casting result: #{inspect(content)}")
     result = Map.get(content, "result", content)
 
     with {:ok, value} <-

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -204,7 +204,6 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     end
   end
 
-
   defp create_retry_message(error) do
     Message.new_user!("""
     Your previous response contained invalid JSON or did not match the required schema.

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -53,29 +53,27 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   end
 
   defp enhance_messages_with_schema(messages, data, json_format, include_examples) do
-    # Find system message and enhance it with schema instructions
-    enhanced_messages =
-      Enum.map(messages, fn message ->
-        case message.role do
-          :system ->
+    # Find the first system message and enhance only that one with schema instructions
+    {enhanced_messages, schema_added?} =
+      Enum.map_reduce(messages, false, fn message, schema_added? ->
+        case {message.role, schema_added?} do
+          {:system, false} ->
             enhanced_content =
               enhance_system_content(message.content, data, json_format, include_examples)
 
-            %{message | content: enhanced_content}
+            {%{message | content: enhanced_content}, true}
 
           _ ->
-            message
+            {message, schema_added?}
         end
       end)
 
     # If no system message found, add one at the beginning
-    case Enum.find(enhanced_messages, &(&1.role == :system)) do
-      nil ->
-        schema_instructions = build_schema_instructions(data, json_format, include_examples)
-        [Message.new_system!(schema_instructions) | enhanced_messages]
-
-      _ ->
-        enhanced_messages
+    if schema_added? do
+      enhanced_messages
+    else
+      schema_instructions = build_schema_instructions(data, json_format, include_examples)
+      [Message.new_system!(schema_instructions) | enhanced_messages]
     end
   end
 

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -190,7 +190,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   end
 
   defp process_response(message, data, attempt) do
-    {:error, "Invalid response format: Got: #{inspect(message)}, data: #{inspect(data)}, attempt: #{attempt}"}
+    {:error,
+     "Invalid response format: Got: #{inspect(message)}, data: #{inspect(data)}, attempt: #{attempt}"}
   end
 
   defp validate_and_cast_result(content, data) do

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -33,13 +33,17 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     json_format = opts[:json_format] || :markdown
     include_examples = Keyword.get(opts, :include_examples, true)
 
-    # Build enhanced system prompt with JSON schema instructions
-    enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
-
-    messages = [
-      Message.new_system!(enhanced_system_prompt),
-      Message.new_user!(data.user_message)
-    ]
+    # Use messages directly if available, fallback to legacy prompts
+    messages = if data.messages do
+      enhance_messages_with_schema(data.messages, data, json_format, include_examples)
+    else
+      # Legacy fallback
+      enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
+      [
+        Message.new_system!(enhanced_system_prompt),
+        Message.new_user!(data.user_message)
+      ]
+    end
 
     Logger.debug("Message processing completed: #{inspect(messages)}")
 
@@ -61,10 +65,88 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
       custom_context: Map.new(Ash.Context.to_opts(data.context))
     }
     |> LLMChain.new!()
-    |> LLMChain.add_messages(messages)
+    |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools(data.tools)
     |> LLMChain.message_processors([json_processor])
     |> run_with_retries(data, max_retries, 0)
+  end
+
+  defp enhance_messages_with_schema(messages, data, json_format, include_examples) do
+    # Find system message and enhance it with schema instructions
+    enhanced_messages = Enum.map(messages, fn message ->
+      case message.role do
+        :system ->
+          enhanced_content = enhance_system_content(message.content, data, json_format, include_examples)
+          %{message | content: enhanced_content}
+        _ ->
+          message
+      end
+    end)
+
+    # If no system message found, add one at the beginning
+    case Enum.find(enhanced_messages, &(&1.role == :system)) do
+      nil ->
+        schema_instructions = build_schema_instructions(data, json_format, include_examples)
+        [Message.new_system!(schema_instructions) | enhanced_messages]
+      _ ->
+        enhanced_messages
+    end
+  end
+
+  defp enhance_system_content(content, data, json_format, include_examples) when is_binary(content) do
+    schema_instructions = build_schema_instructions(data, json_format, include_examples)
+    
+    """
+    #{content}
+
+    #{schema_instructions}
+    """
+  end
+
+  defp enhance_system_content(content, data, json_format, include_examples) when is_list(content) do
+    # For ContentPart lists, add schema instructions as a text part
+    schema_instructions = build_schema_instructions(data, json_format, include_examples)
+    content ++ [LangChain.Message.ContentPart.text!(schema_instructions)]
+  end
+
+  defp build_schema_instructions(data, json_format, include_examples) do
+    schema_json = Jason.encode!(data.json_schema, pretty: true)
+
+    format_instructions =
+      case json_format do
+        :xml ->
+          """
+          <json>
+          {
+            "result": <your response matching the schema>
+          }
+          </json>
+          """
+
+        _ ->
+          """
+          ```json
+          {
+            "result": <your response matching the schema>
+          }
+          ```
+          """
+      end
+
+    example_section = generate_example_section(data, include_examples, json_format)
+
+    """
+
+    IMPORTANT INSTRUCTIONS:
+    You MUST respond with valid JSON that matches the following schema:
+
+    #{schema_json}
+
+    Your response MUST be formatted as:
+    #{format_instructions}
+
+    The JSON must be valid and parseable. Do not include any text before or after the JSON block.#{example_section}
+    """
   end
 
   defp run_with_retries(chain, data, max_retries, attempt) do

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -30,19 +30,7 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     json_format = opts[:json_format] || :markdown
     include_examples = Keyword.get(opts, :include_examples, true)
 
-    # Use messages directly if available, fallback to other prompts
-    messages =
-      if data.messages do
-        enhance_messages_with_schema(data.messages, data, json_format, include_examples)
-      else
-        # other prompt style fallback
-        enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
-
-        [
-          Message.new_system!(enhanced_system_prompt),
-          Message.new_user!(data.user_message)
-        ]
-      end
+    messages = enhance_messages_with_schema(data.messages, data, json_format, include_examples)
 
     regex =
       case json_format do
@@ -216,46 +204,6 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     end
   end
 
-  defp build_enhanced_prompt(data, format, include_examples) do
-    schema_json = Jason.encode!(data.json_schema, pretty: true)
-
-    format_instructions =
-      case format do
-        :xml ->
-          """
-          <json>
-          {
-            "result": <your response matching the schema>
-          }
-          </json>
-          """
-
-        _ ->
-          """
-          ```json
-          {
-            "result": <your response matching the schema>
-          }
-          ```
-          """
-      end
-
-    example_section = generate_example_section(data, include_examples, format)
-
-    """
-    #{data.system_prompt}
-
-    IMPORTANT INSTRUCTIONS:
-    You MUST respond with valid JSON that matches the following schema:
-
-    #{schema_json}
-
-    Your response MUST be formatted as:
-    #{format_instructions}
-
-    The JSON must be valid and parseable. Do not include any text before or after the JSON block.#{example_section}
-    """
-  end
 
   defp create_retry_message(error) do
     Message.new_user!("""

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -23,29 +23,26 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   alias LangChain.Message
   alias LangChain.MessageProcessors.JsonProcessor
 
-  require Logger
-
   @default_max_retries 2
 
   def run(%Data{} = data, opts) do
-    Logger.debug("RequestJson adapter starting")
     max_retries = opts[:max_retries] || @default_max_retries
     json_format = opts[:json_format] || :markdown
     include_examples = Keyword.get(opts, :include_examples, true)
 
-    # Use messages directly if available, fallback to legacy prompts
-    messages = if data.messages do
-      enhance_messages_with_schema(data.messages, data, json_format, include_examples)
-    else
-      # Legacy fallback
-      enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
-      [
-        Message.new_system!(enhanced_system_prompt),
-        Message.new_user!(data.user_message)
-      ]
-    end
+    # Use messages directly if available, fallback to other prompts
+    messages =
+      if data.messages do
+        enhance_messages_with_schema(data.messages, data, json_format, include_examples)
+      else
+        # other prompt style fallback
+        enhanced_system_prompt = build_enhanced_prompt(data, json_format, include_examples)
 
-    Logger.debug("Message processing completed: #{inspect(messages)}")
+        [
+          Message.new_system!(enhanced_system_prompt),
+          Message.new_user!(data.user_message)
+        ]
+      end
 
     regex =
       case json_format do
@@ -53,11 +50,7 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
         _ -> ~r/```json\s*(.*?)\s*```/s
       end
 
-    Logger.debug("Regex processing completed: #{inspect(regex)}")
-
     json_processor = JsonProcessor.new!(regex)
-
-    Logger.debug("About to create LLMChain")
 
     %{
       llm: data.llm,
@@ -73,29 +66,35 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
 
   defp enhance_messages_with_schema(messages, data, json_format, include_examples) do
     # Find system message and enhance it with schema instructions
-    enhanced_messages = Enum.map(messages, fn message ->
-      case message.role do
-        :system ->
-          enhanced_content = enhance_system_content(message.content, data, json_format, include_examples)
-          %{message | content: enhanced_content}
-        _ ->
-          message
-      end
-    end)
+    enhanced_messages =
+      Enum.map(messages, fn message ->
+        case message.role do
+          :system ->
+            enhanced_content =
+              enhance_system_content(message.content, data, json_format, include_examples)
+
+            %{message | content: enhanced_content}
+
+          _ ->
+            message
+        end
+      end)
 
     # If no system message found, add one at the beginning
     case Enum.find(enhanced_messages, &(&1.role == :system)) do
       nil ->
         schema_instructions = build_schema_instructions(data, json_format, include_examples)
         [Message.new_system!(schema_instructions) | enhanced_messages]
+
       _ ->
         enhanced_messages
     end
   end
 
-  defp enhance_system_content(content, data, json_format, include_examples) when is_binary(content) do
+  defp enhance_system_content(content, data, json_format, include_examples)
+       when is_binary(content) do
     schema_instructions = build_schema_instructions(data, json_format, include_examples)
-    
+
     """
     #{content}
 
@@ -103,7 +102,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     """
   end
 
-  defp enhance_system_content(content, data, json_format, include_examples) when is_list(content) do
+  defp enhance_system_content(content, data, json_format, include_examples)
+       when is_list(content) do
     # For ContentPart lists, add schema instructions as a text part
     schema_instructions = build_schema_instructions(data, json_format, include_examples)
     content ++ [LangChain.Message.ContentPart.text!(schema_instructions)]
@@ -150,13 +150,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   end
 
   defp run_with_retries(chain, data, max_retries, attempt) do
-    Logger.debug("RequestJson run_with_retries attempt #{attempt}/#{max_retries}")
-    Logger.debug("About to call LLMChain.run")
-
     case LLMChain.run(chain, mode: :while_needs_response) do
       {:ok, %LLMChain{last_message: %Message{role: :assistant} = message} = updated_chain} ->
-        Logger.debug("LLMChain.run succeeded, processing response")
-
         case process_response(message, data, attempt) do
           {:ok, result} ->
             {:ok, result}
@@ -173,24 +168,16 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
         end
 
       {:error, _, error} ->
-        Logger.debug("LLMChain.run failed with error: #{inspect(error)}")
         {:error, error}
-
-      other ->
-        Logger.debug("LLMChain.run returned unexpected result: #{inspect(other)}")
-        {:error, "Unexpected LLMChain result: #{inspect(other)}"}
     end
   end
 
   defp process_response(%Message{processed_content: content}, data, _attempt)
        when is_map(content) do
-    Logger.debug("Processing response with processed_content: #{inspect(content)}")
-    # JsonProcessor successfully extracted JSON
     validate_and_cast_result(content, data)
   end
 
   defp process_response(%Message{content: content}, data, _attempt) when is_binary(content) do
-    Logger.debug("Processing response with binary content")
     # Fallback: try to parse raw content as JSON
     case Jason.decode(content) do
       {:ok, decoded} ->
@@ -203,12 +190,10 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
   end
 
   defp process_response(message, _, _) do
-    Logger.debug("process_response got unexpected message: #{inspect(message)}")
     {:error, "Invalid response format"}
   end
 
   defp validate_and_cast_result(content, data) do
-    Logger.debug("Validating and casting result: #{inspect(content)}")
     result = Map.get(content, "result", content)
 
     with {:ok, value} <-

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -189,8 +189,8 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     end
   end
 
-  defp process_response(message, _, _) do
-    {:error, "Invalid response format"}
+  defp process_response(message, data, attempt) do
+    {:error, "Invalid response format: Got: #{inspect(message)}, data: #{inspect(data)}, attempt: #{attempt}"}
   end
 
   defp validate_and_cast_result(content, data) do

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -30,10 +30,16 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
         json_response: true
       })
 
-    messages = [
-      Message.new_system!(data.system_prompt),
-      Message.new_user!(data.user_message)
-    ]
+    # Use messages directly if available, fallback to legacy prompts
+    messages = if data.messages do
+      data.messages
+    else
+      # Legacy fallback
+      [
+        Message.new_system!(data.system_prompt),
+        Message.new_user!(data.user_message)
+      ]
+    end
 
     %{
       llm: llm,
@@ -41,7 +47,7 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
       custom_context: Map.new(Ash.Context.to_opts(data.context))
     }
     |> LLMChain.new!()
-    |> LLMChain.add_messages(messages)
+    |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools(data.tools)
     |> LLMChain.run(mode: :while_needs_response)
     |> case do

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -8,7 +8,6 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
-  alias LangChain.Message
 
   def run(%Data{} = data, _opts) do
     if !Map.has_key?(data.llm, :json_schema) do
@@ -30,17 +29,7 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
         json_response: true
       })
 
-    # Use messages directly if available, fallback to legacy prompts
-    messages =
-      if data.messages do
-        data.messages
-      else
-        # Legacy fallback
-        [
-          Message.new_system!(data.system_prompt),
-          Message.new_user!(data.user_message)
-        ]
-      end
+    messages = data.messages
 
     %{
       llm: llm,

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -31,15 +31,16 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
       })
 
     # Use messages directly if available, fallback to legacy prompts
-    messages = if data.messages do
-      data.messages
-    else
-      # Legacy fallback
-      [
-        Message.new_system!(data.system_prompt),
-        Message.new_user!(data.user_message)
-      ]
-    end
+    messages =
+      if data.messages do
+        data.messages
+      else
+        # Legacy fallback
+        [
+          Message.new_system!(data.system_prompt),
+          Message.new_user!(data.user_message)
+        ]
+      end
 
     %{
       llm: llm,

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -324,9 +324,9 @@ defmodule AshAi.Mcp.Server do
         # Handle other notifications (no id)
         {:no_response, nil, session_id}
 
-      _other ->
+      other ->
         # Invalid message
-        {:json_response, json_rpc_error_response(nil, -32_600, "Invalid Request"), session_id}
+        {:json_response, json_rpc_error_response(nil, -32_600, "Invalid Request Got: #{inspect(other)}"), session_id}
     end
   end
 

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -326,7 +326,9 @@ defmodule AshAi.Mcp.Server do
 
       other ->
         # Invalid message
-        {:json_response, json_rpc_error_response(nil, -32_600, "Invalid Request Got: #{inspect(other)}"), session_id}
+        {:json_response,
+         json_rpc_error_response(nil, -32_600, "Invalid Request Got: #{inspect(other)}"),
+         session_id}
     end
   end
 

--- a/test/ash_ai/actions/prompt/adapter/messages_test.exs
+++ b/test/ash_ai/actions/prompt/adapter/messages_test.exs
@@ -1,0 +1,330 @@
+defmodule AshAi.Actions.Prompt.Adapter.MessagesTest do
+  @moduledoc """
+  Tests for all prompt adapters with the new Messages support.
+
+  This test suite ensures that all adapters (RequestJson, CompletionTool, StructuredOutput)
+  properly handle the new Messages format, including:
+  - LangChain Messages with text content
+  - Messages with ContentParts (images + text)
+  - Messages with PromptTemplates
+  - Mixed content scenarios (like OCR with images)
+  """
+  use ExUnit.Case, async: true
+  alias AshAi.ChatFaker
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.PromptTemplate
+  alias __MODULE__.{TestDomain, TestResource}
+
+  defmodule OcrResult do
+    @moduledoc false
+    use Ash.Type.NewType,
+      subtype_of: :map,
+      constraints: [
+        fields: [
+          image_text: [
+            type: :string,
+            allow_nil?: false,
+            description: "The handwritten text in the image"
+          ]
+        ]
+      ]
+  end
+
+  defmodule TestResource do
+    use Ash.Resource,
+      domain: TestDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshAi]
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+    end
+
+    actions do
+      default_accept([:*])
+      defaults([:create, :read, :update, :destroy])
+
+      # Test 1: Messages with image content (OCR scenario) - RequestJson
+      action :ocr_with_messages_request_json, OcrResult do
+        description("OCR using Messages format with RequestJson adapter")
+        argument(:image_data, :binary, allow_nil?: false)
+        argument(:extra_context, :string, allow_nil?: true)
+
+        run prompt(
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, _tools ->
+                    # Verify the image was included in the messages
+                    user_message = Enum.find(messages, &(&1.role == :user))
+                    assert user_message != nil
+
+                    # Check if content is a list with ContentParts
+                    if is_list(user_message.content) do
+                      has_image =
+                        Enum.any?(user_message.content, fn part ->
+                          match?(%ContentPart{type: :image}, part)
+                        end)
+
+                      assert has_image, "Expected image ContentPart in user message"
+                    end
+
+                    json_response = """
+                    ```json
+                    {
+                      "result": {
+                        "image_text": "Hello World"
+                      }
+                    }
+                    ```
+                    """
+
+                    {:ok, Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter: AshAi.Actions.Prompt.Adapter.RequestJson,
+              prompt: fn input, _context ->
+                [
+                  Message.new_system!("You are an expert at OCR of images."),
+                  Message.new_user!([
+                    ContentPart.text!("Please extract text from this image."),
+                    ContentPart.image!(input.arguments.image_data, media: :jpg)
+                  ])
+                ]
+              end
+            )
+      end
+
+      # Test 2: Messages with PromptTemplate - RequestJson
+      action :ocr_with_template_request_json, OcrResult do
+        description("OCR using PromptTemplate in Messages with RequestJson adapter")
+        argument(:image_data, :binary, allow_nil?: false)
+        argument(:extra_context, :string, allow_nil?: true)
+
+        run prompt(
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, _tools ->
+                    # Verify PromptTemplate was processed
+                    user_message = Enum.find(messages, &(&1.role == :user))
+                    assert user_message != nil
+
+                    json_response = """
+                    ```json
+                    {
+                      "result": {
+                        "image_text": "Hello World"
+                      }
+                    }
+                    ```
+                    """
+
+                    {:ok, Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter: AshAi.Actions.Prompt.Adapter.RequestJson,
+              prompt: fn input, _context ->
+                [
+                  Message.new_system!("You are an expert at OCR."),
+                  Message.new_user!([
+                    PromptTemplate.from_template!(
+                      "Extra context: <%= @input.arguments.extra_context %>"
+                    ),
+                    ContentPart.image!(input.arguments.image_data, media: :jpg)
+                  ])
+                ]
+              end
+            )
+      end
+
+      # Test 3: Messages with CompletionTool adapter
+      action :analyze_image_completion_tool, OcrResult do
+        description("Image analysis using Messages with CompletionTool adapter")
+        argument(:image_data, :binary, allow_nil?: false)
+
+        run prompt(
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, tools ->
+                    # Verify image was preserved
+                    user_message = Enum.find(messages, &(&1.role == :user))
+                    assert user_message != nil
+
+                    completion_tool = Enum.find(tools, &(&1.name == "complete_request"))
+                    assert completion_tool != nil
+
+                    tool_call = %LangChain.Message.ToolCall{
+                      status: :complete,
+                      type: :function,
+                      call_id: "call_image_analysis",
+                      name: "complete_request",
+                      arguments: %{
+                        "result" => %{
+                          "image_text" => "Hello World"
+                        }
+                      },
+                      index: 0
+                    }
+
+                    {:ok,
+                     Message.new_assistant!(%{
+                       status: :complete,
+                       tool_calls: [tool_call]
+                     })}
+                  end
+                })
+              end,
+              adapter: AshAi.Actions.Prompt.Adapter.CompletionTool,
+              prompt: fn input, _context ->
+                [
+                  Message.new_system!("You are an expert at image analysis."),
+                  Message.new_user!([
+                    ContentPart.text!("Analyze this image and describe what you see."),
+                    ContentPart.image!(input.arguments.image_data, media: :jpg)
+                  ])
+                ]
+              end
+            )
+      end
+
+      # Test 5: Legacy string prompt (backward compatibility)
+      action :legacy_string_prompt, OcrResult do
+        description("Test legacy string prompt compatibility")
+        argument(:text, :string, allow_nil?: false)
+
+        run prompt(
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, _tools ->
+                    json_response = """
+                    ```json
+                    {
+                      "result": {
+                        "image_text": "Legacy processed text"
+                      }
+                    }
+                    ```
+                    """
+
+                    {:ok, Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter: AshAi.Actions.Prompt.Adapter.RequestJson,
+              prompt: "Process this text: <%= @input.arguments.text %>"
+            )
+      end
+
+      # Test 6: Legacy tuple prompt (backward compatibility)
+      action :legacy_tuple_prompt, OcrResult do
+        description("Test legacy tuple prompt compatibility")
+        argument(:text, :string, allow_nil?: false)
+
+        run prompt(
+              fn _input, _context ->
+                ChatFaker.new!(%{
+                  expect_fun: fn _model, messages, _tools ->
+                    json_response = """
+                    ```json
+                    {
+                      "result": {
+                        "image_text": "Tuple processed text"
+                      }
+                    }
+                    ```
+                    """
+
+                    {:ok, Message.new_assistant!(%{content: json_response})}
+                  end
+                })
+              end,
+              adapter: AshAi.Actions.Prompt.Adapter.RequestJson,
+              prompt: {"You are a text processor", "Process: <%= @input.arguments.text %>"}
+            )
+      end
+    end
+  end
+
+  defmodule TestDomain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource(TestResource)
+    end
+  end
+
+  describe "Messages support in adapters" do
+    setup do
+      # Create a fake image data (base64 encoded small image)
+      image_data =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+      {:ok, image_data: image_data}
+    end
+
+    test "RequestJson adapter processes Messages with images correctly", %{image_data: image_data} do
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:ocr_with_messages_request_json, %{
+          image_data: image_data,
+          extra_context: "test context"
+        })
+        |> Ash.run_action!()
+
+      assert result.image_text == "Hello World"
+    end
+
+    test "RequestJson adapter processes PromptTemplates in Messages", %{image_data: image_data} do
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:ocr_with_template_request_json, %{
+          image_data: image_data,
+          extra_context: "important context"
+        })
+        |> Ash.run_action!()
+
+      assert result.image_text == "Hello World"
+    end
+
+    test "CompletionTool adapter processes Messages with images correctly", %{
+      image_data: image_data
+    } do
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:analyze_image_completion_tool, %{
+          image_data: image_data
+        })
+        |> Ash.run_action!()
+
+      assert result.image_text == "Hello World"
+    end
+
+    test "legacy string prompt still works (backward compatibility)" do
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:legacy_string_prompt, %{
+          text: "test input"
+        })
+        |> Ash.run_action!()
+
+      assert result.image_text == "Legacy processed text"
+    end
+
+    test "legacy tuple prompt still works (backward compatibility)" do
+      result =
+        TestResource
+        |> Ash.ActionInput.for_action(:legacy_tuple_prompt, %{
+          text: "test input"
+        })
+        |> Ash.run_action!()
+
+      assert result.image_text == "Tuple processed text"
+    end
+  end
+end


### PR DESCRIPTION

  ## Prompt

  The prompt by default is generated using the action and input descriptions. You can provide your own prompt
  via the `prompt` option which supports multiple formats based on the type of data provided:

  ### Supported Formats

  1. **String (EEx template)**: `"Analyze this: <%= @input.arguments.text %>"`
  2. **{System, User} tuple**: `{"You are an expert", "Analyze the sentiment"}`
  3. **Function**: `fn input, context -> {"Dynamic system", "Dynamic user"} end`
  4. **List of LangChain Messages**: `[Message.new_system!("..."), Message.new_user!("...")]`
  5. **Function returning Messages**: `fn input, context -> [Message.new_system!("...")] end`

  ### Examples

  #### Basic String Template
  ```elixir
  run prompt(
    ChatOpenAI.new!(%{model: "gpt-4o"}),
    prompt: "Analyze the sentiment of: <%= @input.arguments.text %>"
  )
  ```

  #### System/User Tuple
  ```elixir
  run prompt(
    ChatOpenAI.new!(%{model: "gpt-4o"}),
    prompt: {"You are a sentiment analyzer", "Analyze: <%= @input.arguments.text %>"}
  )
  ```

  #### LangChain Messages for Multi-turn Conversations
  ```elixir
  run prompt(
    ChatOpenAI.new!(%{model: "gpt-4o"}),
    prompt: [
      Message.new_system!("You are an expert assistant"),
      Message.new_user!("Hello, how can you help me?"),
      Message.new_assistant!("I can help with various tasks"),
      Message.new_user!("Great! Please analyze this data")
    ]
  )
  ```

  #### Image Analysis with Templates
  ```elixir
  run prompt(
    ChatOpenAI.new!(%{model: "gpt-4o"}),
    prompt: [
      Message.new_system!("You are an expert at image analysis"),
      Message.new_user!([
        PromptTemplate.from_template!("Extra context: <%= @input.arguments.context %>"),
        ContentPart.image!("<%= @input.arguments.image_data %>", media: :jpg, detail: "low")
      ])
    ]
  )
  ```

  #### Dynamic Messages via Function
  ```elixir
  run prompt(
    ChatOpenAI.new!(%{model: "gpt-4o"}),
    prompt: fn input, context ->
      base = [Message.new_system!("You are helpful")]

      history = input.arguments.conversation_history
      |> Enum.map(fn %{"role" => role, "content" => content} ->
        case role do
          "user" -> Message.new_user!(content)
          "assistant" -> Message.new_assistant!(content)
        end
      end)

      base ++ history
    end
  )
  ```

  ### Template Processing

  - **String prompts**: Processed as EEx templates with `@input` and `@context`
  - **Messages with PromptTemplate**: Processed using LangChain's `apply_prompt_templates`
  - **Functions**: Can return any supported format for dynamic generation


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
