### PR TITLE
Fix crash with embedded resource

### DIFF
--- a/lib/ash_ai/open_api.ex
+++ b/lib/ash_ai/open_api.ex
@@ -167,7 +167,7 @@ defmodule AshAi.OpenApi do
             Map.put(acc, key, value)
           else
             description = value |> Map.get(:description)
-            value = value |> Map.put(:description, nil)
+            value = value |> Map.delete(:description)
 
             new_value =
               %{

--- a/lib/ash_ai/open_api.ex
+++ b/lib/ash_ai/open_api.ex
@@ -618,7 +618,7 @@ defmodule AshAi.OpenApi do
         %{
           type: :object,
           additionalProperties: false,
-          properties: resource_attributes(instance_of, nil, format, false),
+          properties: resource_attributes(instance_of, format, false),
           required: required_attributes(instance_of)
         }
         |> add_null_for_non_required()
@@ -638,7 +638,7 @@ defmodule AshAi.OpenApi do
         %{
           type: :object,
           additionalProperties: false,
-          properties: resource_attributes(type, nil, format, false),
+          properties: resource_attributes(type, format, false),
           required: required_attributes(type)
         }
         |> add_null_for_non_required()
@@ -666,13 +666,12 @@ defmodule AshAi.OpenApi do
 
   @spec resource_attributes(
           resource :: module,
-          fields :: nil | list(atom),
           format :: content_type_format(),
           hide_pkeys? :: boolean()
         ) :: %{
           atom => map()
         }
-  defp resource_attributes(resource, fields, format, hide_pkeys?) do
+  defp resource_attributes(resource, format, hide_pkeys?) do
     resource
     |> Ash.Resource.Info.public_attributes()
     |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
@@ -729,7 +728,7 @@ defmodule AshAi.OpenApi do
        resource_attribute_type(attr, resource, format)
        |> with_attribute_description(attr)
        |> with_attribute_nullability(attr)
-       |> with_comment_on_included(attr, fields)}
+       |> with_comment_on_included()}
     end)
   end
 
@@ -740,25 +739,21 @@ defmodule AshAi.OpenApi do
     |> Enum.map(& &1.name)
   end
 
-  @spec with_comment_on_included(map(), map(), nil | list(atom)) :: map()
-  defp with_comment_on_included(schema, attr, fields) do
+  @spec with_comment_on_included(map()) :: map()
+  defp with_comment_on_included(schema) do
     key = if Map.has_key?(schema, :description), do: :description, else: "description"
 
     new_description =
-      if is_nil(fields) || attr.name in fields do
-        case Map.get(schema, key) do
-          nil ->
-            "Field included by default."
+      case Map.get(schema, key) do
+        nil ->
+          "Field included by default."
 
-          description ->
-            if String.ends_with?(description, ["!", "."]) do
-              description <> " Field included by default."
-            else
-              description <> ". Field included by default."
-            end
-        end
-      else
-        Map.get(schema, key) || ""
+        description ->
+          if String.ends_with?(description, ["!", "."]) do
+            description <> " Field included by default."
+          else
+            description <> ". Field included by default."
+          end
       end
 
     Map.put(schema, key, new_description)

--- a/lib/ash_ai/open_api.ex
+++ b/lib/ash_ai/open_api.ex
@@ -514,7 +514,7 @@ defmodule AshAi.OpenApi do
   end
 
   defp resource_attribute_type(%{type: Ash.Type.Date}, _resource, _format) do
-    %{type: :number, format: :date}
+    %{type: :string, format: :date}
   end
 
   defp resource_attribute_type(%{type: Ash.Type.UtcDatetime}, _resource, _format) do
@@ -745,7 +745,7 @@ defmodule AshAi.OpenApi do
     key = if Map.has_key?(schema, :description), do: :description, else: "description"
 
     new_description =
-      if attr.name in fields do
+      if is_nil(fields) || attr.name in fields do
         case Map.get(schema, key) do
           nil ->
             "Field included by default."

--- a/test/ash_ai/open_api_test.exs
+++ b/test/ash_ai/open_api_test.exs
@@ -2,7 +2,7 @@ defmodule AshAi.OpenApiTest do
   use ExUnit.Case, async: true
   alias AshAi.ChatFaker
 
-  alias __MODULE__.{Music, Artist, Album}
+  alias __MODULE__.{Music, Artist, Album, Schema}
 
   defmodule Bio do
     use Ash.Resource, data_layer: :embedded
@@ -258,7 +258,7 @@ defmodule AshAi.OpenApiTest do
               resource,
               &AshJsonApi.OpenApi.resource_write_attribute_type/4
             )
-            |> OpenApiSpex.OpenApi.to_map()
+            |> Schema.to_map()
 
           assert vendored_schema == old_schema
         end
@@ -279,7 +279,7 @@ defmodule AshAi.OpenApiTest do
               resource,
               AshJsonApi.OpenApi
             )
-            |> OpenApiSpex.OpenApi.to_map()
+            |> Schema.to_map()
 
           assert vendored_schema == old_schema
         end
@@ -344,5 +344,78 @@ defmodule AshAi.OpenApiTest do
         value
       )
     end)
+  end
+
+  defmodule Schema do
+    alias OpenApiSpex.Extendable
+
+    @vendor_extensions ~w(
+      x-struct
+      x-validate
+      x-parameter-content-parsers
+    )
+
+    def to_map(value), do: to_map(value, [])
+    def to_map(%Regex{source: source}, _opts), do: source
+
+    def to_map(%object{} = value, opts) when object in [MediaType, Schema, Example] do
+      value
+      |> Extendable.to_map()
+      |> Stream.map(fn
+        {:value, v} when object == Example -> {"value", to_map_example(v, opts)}
+        {:example, v} -> {"example", to_map_example(v, opts)}
+        {k, v} -> {to_string(k), to_map(v, opts)}
+      end)
+      |> Stream.filter(fn
+        {k, _} when k in @vendor_extensions -> opts[:vendor_extensions]
+        {_, nil} -> false
+        _ -> true
+      end)
+      |> Enum.into(%{})
+    end
+
+    def to_map(value = %{__struct__: _}, opts) do
+      value
+      |> Extendable.to_map()
+      |> to_map(opts)
+    end
+
+    def to_map(value, opts) when is_map(value) do
+      value
+      |> Stream.map(fn {k, v} -> {to_string(k), to_map(v, opts)} end)
+      |> Stream.filter(fn
+        {_, nil} -> false
+        _ -> true
+      end)
+      |> Enum.into(%{})
+    end
+
+    def to_map(value, opts) when is_list(value) do
+      Enum.map(value, &to_map(&1, opts))
+    end
+
+    def to_map(nil, _opts), do: nil
+    def to_map(true, _opts), do: true
+    def to_map(false, _opts), do: false
+    def to_map(value, _opts) when is_atom(value), do: to_string(value)
+    def to_map(value, _opts), do: value
+
+    defp to_map_example(value = %{__struct__: _}, opts) do
+      value
+      |> Extendable.to_map()
+      |> to_map_example(opts)
+    end
+
+    defp to_map_example(value, opts) when is_map(value) do
+      value
+      |> Stream.map(fn {k, v} -> {to_string(k), to_map_example(v, opts)} end)
+      |> Enum.into(%{})
+    end
+
+    defp to_map_example(value, opts) when is_list(value) do
+      Enum.map(value, &to_map_example(&1, opts))
+    end
+
+    defp to_map_example(value, opts), do: to_map(value, opts)
   end
 end

--- a/test/ash_ai/open_api_test.exs
+++ b/test/ash_ai/open_api_test.exs
@@ -374,7 +374,7 @@ defmodule AshAi.OpenApiTest do
       |> Enum.into(%{})
     end
 
-    def to_map(value = %{__struct__: _}, opts) do
+    def to_map(%{__struct__: _} = value, opts) do
       value
       |> Extendable.to_map()
       |> to_map(opts)
@@ -400,7 +400,7 @@ defmodule AshAi.OpenApiTest do
     def to_map(value, _opts) when is_atom(value), do: to_string(value)
     def to_map(value, _opts), do: value
 
-    defp to_map_example(value = %{__struct__: _}, opts) do
+    defp to_map_example(%{__struct__: _} = value, opts) do
       value
       |> Extendable.to_map()
       |> to_map_example(opts)

--- a/test/ash_ai/open_api_test.exs
+++ b/test/ash_ai/open_api_test.exs
@@ -4,6 +4,14 @@ defmodule AshAi.OpenApiTest do
 
   alias __MODULE__.{Music, Artist, Album}
 
+  defmodule Bio do
+    use Ash.Resource, data_layer: :embedded
+
+    attributes do
+      attribute :birth, :date, allow_nil?: false, public?: true
+    end
+  end
+
   defmodule Artist do
     use Ash.Resource,
       domain: Music,
@@ -16,6 +24,7 @@ defmodule AshAi.OpenApiTest do
     attributes do
       uuid_v7_primary_key(:id, writable?: true)
       attribute(:name, :string, public?: true)
+      attribute(:bio, Bio, allow_nil?: false, public?: true)
     end
 
     actions do


### PR DESCRIPTION
Fix crash with embedded resource

```
  1) test AshJsonApi.OpenApi vendoring regression tests for action specific properties (AshAi.OpenApiTest)
     test/ash_ai/open_api_test.exs:268
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for type Atom

     Got value:

         nil
     
     stacktrace:
       (elixir 1.18.3) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir 1.18.3) lib/enum.ex:194: Enumerable.member?/2
       (elixir 1.18.3) lib/enum.ex:2020: Enum.member?/2
       (ash_ai 0.2.3) lib/ash_ai/open_api.ex:748: AshAi.OpenApi.with_comment_on_included/3
       (ash_ai 0.2.3) lib/ash_ai/open_api.ex:732: anonymous fn/4 in AshAi.OpenApi.resource_attributes/4
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/map.ex:262: Map.new_from_enum/2
       (ash_ai 0.2.3) lib/ash_ai/open_api.ex:641: AshAi.OpenApi.resource_attribute_type/3
       (ash_ai 0.2.3) lib/ash_ai/open_api.ex:898: AshAi.OpenApi.filter_fields/5
       (elixir 1.18.3) lib/enum.ex:4442: Enum.flat_map_list/2
       (elixir 1.18.3) lib/enum.ex:4445: Enum.flat_map_list/2
       (ash_ai 0.2.3) lib/ash_ai/open_api.ex:863: AshAi.OpenApi.raw_filter_type/2
       test/ash_ai/open_api_test.exs:294: anonymous fn/3 in AshAi.OpenApiTest.get_action_specific_properties/3
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/map.ex:262: Map.new_from_enum/2
       test/ash_ai/open_api_test.exs:272: anonymous fn/2 in AshAi.OpenApiTest."test AshJsonApi.OpenApi vendoring regression tests for action specific properties"/1
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       test/ash_ai/open_api_test.exs:270: anonymous fn/2 in AshAi.OpenApiTest."test AshJsonApi.OpenApi vendoring regression tests for action specific properties"/1
```

Added `Schema.to_map/1` for testing purposes. The original `OpenApiSpex.OpenApi.to_map/1` removed `required: []`, which caused comparison failures, so I copied and adjusted it to preserve empty required lists.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
