### PR TITLE
improvement: add documentation for tool private attribute behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,25 @@ mix test.full_reset
    ```elixir
    tools do
      tool :tool_name, Resource, :action_name
+     
+     # With custom description
+     tool :read_posts, Post, :read do
+       description "Read all blog posts with optional filtering"
+     end
+     
+     # With loading relationships/calculations
+     tool :read_posts_with_author, Post, :read do
+       load [:author, :comment_count]
+     end
    end
    ```
+   
+   **Important Tool Considerations:**
+   - Only public attributes (`public?: true`) are accessible for filtering, sorting, and aggregation
+   - Private attributes cannot be filtered, sorted, or used in aggregates
+   - Use the `load` option to include relationships, calculations, or additional attributes in responses
+   - When using `load`, even private attributes become visible in tool responses
+   - Tool descriptions help LLMs understand when and how to use each tool
 
 3. **Prompt-Backed Actions**: Actions where the implementation is delegated to an LLM using structured outputs to ensure type safety.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,32 @@ end
 Expose these actions as tools. When you call `AshAi.setup_ash_ai(chain, opts)`, or `AshAi.iex_chat/2`
 it will add those as tool calls to the agent.
 
+### Tool Data Access
+
+**Important**: Tools have different access levels for different operations:
+- **Filtering/Sorting/Aggregation**: Only public attributes (`public?: true`) can be used
+- **Arguments**: Only public action arguments are exposed
+- **Response data**: Public attributes are returned by default
+- **Loading data**: Use the `load` option to include relationships, calculations, or additional attributes (including private ones) in responses
+
+Example:
+```elixir
+tools do
+  # Returns only public attributes
+  tool :read_posts, MyApp.Blog.Post, :read
+  
+  # Returns public attributes AND loaded relationships/calculations
+  # Note: loaded fields can include private attributes
+  tool :read_posts_with_details, MyApp.Blog.Post, :read,
+    load: [:author, :comment_count, :internal_notes]
+end
+```
+
+Key distinction:
+- Private attributes cannot be used for filtering, sorting, or aggregation
+- Private attributes CAN be included in responses when using the `load` option
+- The `load` option is primarily for loading relationships and calculations, but also makes any loaded attributes (including private ones) visible
+
 ## Prompt-backed actions
 
 This allows defining an action, including input and output types, and delegating the

--- a/documentation/dsls/DSL-AshAi.md
+++ b/documentation/dsls/DSL-AshAi.md
@@ -22,6 +22,11 @@ tool name, resource, action
 ```
 
 
+Expose an Ash action as a tool that can be called by LLMs.
+
+Tools allow LLMs to interact with your application by calling specific actions on resources.
+Only public attributes can be used for filtering, sorting, and aggregation, but the `load`
+option allows including private attributes in the response data.
 
 
 
@@ -39,7 +44,7 @@ tool name, resource, action
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`load`](#tools-tool-load){: #tools-tool-load } | `any` | `[]` |  |
+| [`load`](#tools-tool-load){: #tools-tool-load } | `any` | `[]` | A list of relationships and calculations to load on the returned records. Note that loaded fields can include private attributes, which will then be included in the tool's response. However, private attributes cannot be used for filtering, sorting, or aggregation. |
 | [`async`](#tools-tool-async){: #tools-tool-async } | `boolean` | `true` |  |
 | [`description`](#tools-tool-description){: #tools-tool-description } | `String.t` |  | A description for the tool. Defaults to the action's description. |
 | [`identity`](#tools-tool-identity){: #tools-tool-identity } | `atom` |  | The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely. |

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -79,7 +79,7 @@ defmodule AshAi do
     target: Tool,
     describe: """
     Expose an Ash action as a tool that can be called by LLMs.
-    
+
     Tools allow LLMs to interact with your application by calling specific actions on resources.
     Only public attributes can be used for filtering, sorting, and aggregation, but the `load`
     option allows including private attributes in the response data.

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -77,11 +77,23 @@ defmodule AshAi do
   @tool %Spark.Dsl.Entity{
     name: :tool,
     target: Tool,
+    describe: """
+    Expose an Ash action as a tool that can be called by LLMs.
+    
+    Tools allow LLMs to interact with your application by calling specific actions on resources.
+    Only public attributes can be used for filtering, sorting, and aggregation, but the `load`
+    option allows including private attributes in the response data.
+    """,
     schema: [
       name: [type: :atom, required: true],
       resource: [type: {:spark, Ash.Resource}, required: true],
       action: [type: :atom, required: true],
-      load: [type: :any, default: []],
+      load: [
+        type: :any,
+        default: [],
+        doc:
+          "A list of relationships and calculations to load on the returned records. Note that loaded fields can include private attributes, which will then be included in the tool's response. However, private attributes cannot be used for filtering, sorting, or aggregation."
+      ],
       async: [type: :boolean, default: true],
       description: [
         type: :string,

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -1,0 +1,169 @@
+defmodule AshAi.ToolTest do
+  use ExUnit.Case, async: true
+  alias AshAi.ChatFaker
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Message
+  alias __MODULE__.{TestDomain, TestResource}
+
+  defmodule TestResource do
+    use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+
+      # Public attributes
+      attribute :public_name, :string, public?: true
+      attribute :public_email, :string, public?: true
+
+      # Private attributes (default is public?: false)
+      attribute :private_notes, :string
+      attribute :internal_status, :string
+    end
+
+    actions do
+      defaults [:read, :create]
+      default_accept [:id, :public_name, :public_email, :private_notes, :internal_status]
+    end
+  end
+
+  defmodule TestDomain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource TestResource
+    end
+
+    tools do
+      tool :read_test_resources, TestResource, :read, load: [:internal_status]
+    end
+  end
+
+  describe "tool response" do
+    setup do
+      # Create test data with both public and private attributes
+      resource =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{
+          id: "0197b375-4daa-7112-a9d8-7f0104485646",
+          public_name: "John Doe",
+          public_email: "john@example.com",
+          private_notes: "Secret internal notes",
+          internal_status: "classified"
+        })
+        |> Ash.create!(domain: TestDomain)
+
+      {:ok, resource: resource}
+    end
+
+    test "includes public and loaded fields", %{resource: resource} do
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      {:ok, chain} = chain() |> run_chain(tool_call)
+
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      # ID is included because it's a primary key
+      # Public name and email are included because they're public attributes
+      # Internal status is included because it's a loaded field
+      assert tool_result.content ==
+               "[{\"id\":\"0197b375-4daa-7112-a9d8-7f0104485646\",\"public_name\":\"John Doe\",\"public_email\":\"john@example.com\",\"internal_status\":\"classified\"}]"
+    end
+  end
+
+  describe "tool parameter schema visibility" do
+    test "filter parameters only include public attributes" do
+      tool = get_test_tool()
+
+      assert tool.name == "read_test_resources"
+      filter_properties = tool.parameters_schema["properties"]["filter"]["properties"]
+
+      # Public attributes are present
+      assert Map.has_key?(filter_properties, "id")
+      assert Map.has_key?(filter_properties, "public_name")
+      assert Map.has_key?(filter_properties, "public_email")
+
+      # Private attributes are not present
+      refute Map.has_key?(filter_properties, "private_notes")
+      refute Map.has_key?(filter_properties, "internal_status")
+    end
+
+    test "sort field options only include public attributes" do
+      tool = get_test_tool()
+
+      sort_field_enum =
+        tool.parameters_schema["properties"]["sort"]["items"]["properties"]["field"]["enum"]
+
+      # Public attributes are present
+      assert "id" in sort_field_enum
+      assert "public_name" in sort_field_enum
+      assert "public_email" in sort_field_enum
+
+      # Private attributes are not present
+      refute "private_notes" in sort_field_enum
+      refute "internal_status" in sort_field_enum
+    end
+
+    test "aggregate field options only include public attributes" do
+      tool = get_test_tool()
+
+      result_type_options = tool.parameters_schema["properties"]["result_type"]["oneOf"]
+
+      aggregate_option =
+        Enum.find(result_type_options, fn opt ->
+          Map.has_key?(opt, "properties") && Map.has_key?(opt["properties"], "aggregate")
+        end)
+
+      aggregate_field_enum = aggregate_option["properties"]["field"]["enum"]
+
+      # Public attributes are present
+      assert "id" in aggregate_field_enum
+      assert "public_name" in aggregate_field_enum
+      assert "public_email" in aggregate_field_enum
+
+      # Private attributes are not present
+      refute "private_notes" in aggregate_field_enum
+      refute "internal_status" in aggregate_field_enum
+    end
+  end
+
+  defp chain do
+    actions =
+      AshAi.Info.tools(TestDomain)
+      |> Enum.group_by(& &1.resource, & &1.action)
+      |> Map.to_list()
+
+    %{llm: ChatFaker.new!(%{})}
+    |> LLMChain.new!()
+    |> AshAi.setup_ash_ai(actions: actions)
+  end
+
+  defp run_chain(chain, tool_call) do
+    chain
+    |> LLMChain.add_message(Message.new_assistant!(%{status: :complete, tool_calls: [tool_call]}))
+    |> LLMChain.run(mode: :while_needs_response)
+  end
+
+  defp get_test_tool do
+    actions =
+      AshAi.Info.tools(TestDomain)
+      |> Enum.group_by(& &1.resource, & &1.action)
+      |> Map.to_list()
+
+    %{llm: ChatFaker.new!(%{})}
+    |> LLMChain.new!()
+    |> AshAi.setup_ash_ai(actions: actions)
+    |> Map.get(:tools)
+    |> Enum.at(0)
+  end
+end


### PR DESCRIPTION
This PR adds some documentation around how attributes are exposed in the tools. I also added tests to demonstrate the behaviour.

Changes:
- Only public attributes can be used for filtering, sorting, and aggregation
- Private attributes can be included in responses via the `load` option
- Added tests demonstrating the behavior

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
