### PR TITLE
fix error "The pin operator ^ is supported only inside matches or ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ read :search do
       {:ok, [search_vector]} ->
         Ash.Query.filter(
           query,
-          vector_cosine_distance(full_text_vector, ^search_vector) < 0.5
+          expr(vector_cosine_distance(full_text_vector, ^search_vector) < 0.5)
         )
         |> Ash.Query.sort(
           {calc(vector_cosine_distance(full_text_vector, ^search_vector),

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -120,7 +120,7 @@ read :semantic_search do
       {:ok, [search_vector]} ->
         Ash.Query.filter(
           query,
-          vector_cosine_distance(full_text_vector, ^search_vector) < 0.5
+          expr(vector_cosine_distance(full_text_vector, ^search_vector) < 0.5)
         )
         |> Ash.Query.sort(asc: vector_cosine_distance(full_text_vector, ^search_vector))
 


### PR DESCRIPTION
Need to wrap expression in `expr` otherwise it shows: 
```sh
Compiling 3 files (.ex)
     error: misplaced operator ^search_vector

     The pin operator ^ is supported only inside matches or inside custom macros. Make sure you are inside a match or all necessary macros have been required
     │
 108 │                       vector_cosine_distance(full_text_vector, ^search_vector) < 0.5
     │                                                                ^
     │
     └─ lib/masque/documents/post.ex:108:64: Masque.Documents.Post.query_before_action_0_generated_7E81229823A9FA03A5A78089B4B26FE5/2

     error: undefined variable "full_text_vector"
     │
 108 │                       vector_cosine_distance(full_text_vector, ^search_vector) < 0.5
     │                                              ^^^^^^^^^^^^^^^^
     │
     └─ lib/masque/documents/post.ex:108:46: Masque.Documents.Post.query_before_action_0_generated_7E81229823A9FA03A5A78089B4B26FE5/2
```
my `.tool-versions`
```txt
erlang 27.3.3
elixir 1.18.4-otp-27
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
