### PR TITLE
fix: separate custom_context from llm initialization in ash_ai.gen.chat

### DIFF
--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -226,7 +226,8 @@ if Code.ensure_loaded?(Igniter) do
             end)
 
           %{
-            llm: ChatOpenAI.new!(%{model: "gpt-4o", custom_context: Map.new(Ash.Context.to_opts(context))}),
+            llm: ChatOpenAI.new!(%{model: "gpt-4o"}),
+            custom_context: Map.new(Ash.Context.to_opts(context)),
             verbose?: true
           }
           |> LLMChain.new!()
@@ -481,7 +482,8 @@ if Code.ensure_loaded?(Igniter) do
           new_message_id = Ash.UUID.generate()
 
           %{
-            llm: ChatOpenAI.new!(%{model: "gpt-4o", stream: true, custom_context: Map.new(Ash.Context.to_opts(context))})
+            llm: ChatOpenAI.new!(%{model: "gpt-4o", stream: true}),
+            custom_context: Map.new(Ash.Context.to_opts(context))
           }
           |> LLMChain.new!()
           |> LLMChain.add_message(system_prompt)
@@ -843,7 +845,7 @@ if Code.ensure_loaded?(Igniter) do
             :error ->
               {:warning,
                """
-               AshAi: Couldn't add the chat routes to `#{inspect(router)}`. 
+               AshAi: Couldn't add the chat routes to `#{inspect(router)}`.
                Please add them manually.
 
                #{live}
@@ -898,10 +900,10 @@ if Code.ensure_loaded?(Igniter) do
         else
           igniter =
             Igniter.add_warning(igniter, """
-            `ash_ai.gen.chat` works better if a user module is known. 
+            `ash_ai.gen.chat` works better if a user module is known.
             We could not find one automatically, and one was not provided.
 
-            Please abort this command and provide one using the `--user` flag, 
+            Please abort this command and provide one using the `--user` flag,
             or install `AshAuthentication` before-hand, being sure its installed
             before this command is run.
             """)


### PR DESCRIPTION
Fixes https://github.com/ash-project/ash_ai/issues/87

I've tested the `mix ash_ai.gen.chat --live` task using the following project:

```bash
mix archive.install hex igniter_new --force
mix archive.install hex phx_new 1.8.0-rc.3 --force

mix igniter.new chat_ui_fix_test --with phx.new --install ash,ash_phoenix \
  --install ash_postgres,ash_authentication \
  --install ash_authentication_phoenix,ash_admin --install live_debugger \
  --auth-strategy magic_link --yes \
  --install ash_ai@path:../ash_ai # local repo with the changes

cd chat_ui_fix_test && mix ash.setup

mix ash_ai.gen.chat --live

mix ash.setup

mix phx.server
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
