### PR TITLE
Add on_tool_start and on_tool_end callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ Key distinction:
 - Private attributes CAN be included in responses when using the `load` option
 - The `load` option is primarily for loading relationships and calculations, but also makes any loaded attributes (including private ones) visible
 
+### Tool Execution Callbacks
+
+Monitor tool execution in real-time by providing callbacks to `AshAi.setup_ash_ai/2`:
+
+```elixir
+chain
+|> AshAi.setup_ash_ai(
+  actor: current_user,
+  on_tool_start: fn %AshAi.ToolStartEvent{} = event ->
+    # event includes: tool_name, action, resource, arguments, actor, tenant
+    IO.puts("Starting #{event.tool_name}...")
+  end,
+  on_tool_end: fn %AshAi.ToolEndEvent{} = event ->
+    # event includes: tool_name, result ({:ok, ...} or {:error, ...})
+    IO.puts("Completed #{event.tool_name}")
+  end
+)
+```
+
+This is useful for showing progress indicators, logging, metrics collection, or debugging tool execution.
+
 ## Prompt-backed actions
 
 This allows defining an action, including input and output types, and delegating the

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -314,20 +314,14 @@ defmodule AshAi do
 
     lang_chain
     |> LLMChain.add_tools(tools)
-    |> then(fn llm_chain ->
-      if opts.actor || opts.on_tool_start || opts.on_tool_end do
-        LLMChain.update_custom_context(llm_chain, %{
-          actor: opts.actor,
-          tenant: opts.tenant,
-          tool_callbacks: %{
-            on_tool_start: opts.on_tool_start,
-            on_tool_end: opts.on_tool_end
-          }
-        })
-      else
-        llm_chain
-      end
-    end)
+    |> LLMChain.update_custom_context(%{
+      actor: opts.actor,
+      tenant: opts.tenant,
+      tool_callbacks: %{
+        on_tool_start: opts.on_tool_start,
+        on_tool_end: opts.on_tool_end
+      }
+    })
   end
 
   defp run_loop(chain, first? \\ false) do

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -74,6 +74,38 @@ defmodule AshAi do
     defstruct [:name, :resource, :action, :load, :async, :domain, :identity, :description]
   end
 
+  defmodule ToolStartEvent do
+    @moduledoc """
+    Event data passed to the `on_tool_start` callback passed to `AshAi.setup_ash_ai/2`.
+
+    Contains information about the tool execution that is about to begin.
+    """
+    @type t :: %__MODULE__{
+            tool_name: String.t(),
+            action: atom(),
+            resource: module(),
+            arguments: map(),
+            actor: any() | nil,
+            tenant: any() | nil
+          }
+
+    defstruct [:tool_name, :action, :resource, :arguments, :actor, :tenant]
+  end
+
+  defmodule ToolEndEvent do
+    @moduledoc """
+    Event data passed to the `on_tool_end` callback passed to `AshAi.setup_ash_ai/2`.
+
+    Contains the tool name and execution result.
+    """
+    @type t :: %__MODULE__{
+            tool_name: String.t(),
+            result: {:ok, String.t(), any()} | {:error, String.t()}
+          }
+
+    defstruct [:tool_name, :result]
+  end
+
   @tool %Spark.Dsl.Entity{
     name: :tool,
     target: Tool,
@@ -179,6 +211,46 @@ defmodule AshAi do
           You will want to include something like the actor's id if you are chatting as an
           actor.
           """
+        ],
+        on_tool_start: [
+          type: {:fun, 1},
+          required: false,
+          doc: """
+          A callback function that is called when a tool execution starts.
+
+          Receives an `AshAi.ToolStartEvent` struct with the following fields:
+          - `:tool_name` - The name of the tool being called
+          - `:action` - The action being performed
+          - `:resource` - The resource the action is on
+          - `:arguments` - The arguments passed to the tool
+          - `:actor` - The actor performing the action
+          - `:tenant` - The tenant context
+
+          Example:
+          ```
+          on_tool_start: fn %AshAi.ToolStartEvent{} = event ->
+            IO.puts("Starting tool: \#{event.tool_name}")
+          end
+          ```
+          """
+        ],
+        on_tool_end: [
+          type: {:fun, 1},
+          required: false,
+          doc: """
+          A callback function that is called when a tool execution completes.
+
+          Receives an `AshAi.ToolEndEvent` struct with the following fields:
+          - `:tool_name` - The name of the tool
+          - `:result` - The result of the tool execution (either {:ok, ...} or {:error, ...})
+
+          Example:
+          ```
+          on_tool_end: fn %AshAi.ToolEndEvent{} = event ->
+            IO.puts("Completed tool: \#{event.tool_name}")
+          end
+          ```
+          """
         ]
       ]
   end
@@ -243,10 +315,14 @@ defmodule AshAi do
     lang_chain
     |> LLMChain.add_tools(tools)
     |> then(fn llm_chain ->
-      if opts.actor do
+      if opts.actor || opts.on_tool_start || opts.on_tool_end do
         LLMChain.update_custom_context(llm_chain, %{
           actor: opts.actor,
-          tenant: opts.tenant
+          tenant: opts.tenant,
+          tool_callbacks: %{
+            on_tool_start: opts.on_tool_start,
+            on_tool_end: opts.on_tool_end
+          }
         })
       else
         llm_chain
@@ -370,241 +446,264 @@ defmodule AshAi do
         input = arguments["input"] || %{}
         opts = [domain: domain, actor: actor, tenant: tenant, context: context[:context] || %{}]
 
-        try do
-          case action.type do
-            :read ->
-              sort =
-                case arguments["sort"] do
-                  sort when is_list(sort) ->
-                    Enum.map(sort, fn map ->
-                      case map["direction"] || "asc" do
-                        "asc" -> map["field"]
-                        "desc" -> "-#{map["field"]}"
-                      end
-                    end)
+        callbacks = context[:tool_callbacks] || %{}
 
-                  nil ->
-                    []
-                end
-                |> Enum.join(",")
-
-              resource
-              |> Ash.Query.limit(arguments["limit"] || 25)
-              |> Ash.Query.offset(arguments["offset"])
-              |> then(fn query ->
-                if sort != "" do
-                  Ash.Query.sort_input(query, sort)
-                else
-                  query
-                end
-              end)
-              |> then(fn query ->
-                if Map.has_key?(arguments, "filter") do
-                  Ash.Query.filter_input(query, arguments["filter"])
-                else
-                  query
-                end
-              end)
-              |> Ash.Query.for_read(action.name, input, opts)
-              |> then(fn query ->
-                result_type = arguments["result_type"] || "run_query"
-
-                case result_type do
-                  "run_query" ->
-                    query
-                    |> Ash.Actions.Read.unpaginated_read(action, load: load)
-                    |> case do
-                      {:ok, value} ->
-                        value
-
-                      {:error, error} ->
-                        raise Ash.Error.to_error_class(error)
-                    end
-                    |> then(fn result ->
-                      result
-                      |> AshAi.Serializer.serialize_value({:array, resource}, [], domain,
-                        load: load
-                      )
-                      |> Jason.encode!()
-                      |> then(&{:ok, &1, result})
-                    end)
-
-                  "count" ->
-                    query
-                    |> Ash.count()
-                    |> case do
-                      {:ok, value} ->
-                        value
-
-                      {:error, error} ->
-                        raise Ash.Error.to_error_class(error)
-                    end
-                    |> then(fn result ->
-                      result
-                      |> AshAi.Serializer.serialize_value(Ash.Type.Integer, [], domain)
-                      |> Jason.encode!()
-                      |> then(&{:ok, &1, result})
-                    end)
-
-                  "exists" ->
-                    query
-                    |> Ash.exists()
-                    |> case do
-                      {:ok, value} ->
-                        value
-
-                      {:error, error} ->
-                        raise Ash.Error.to_error_class(error)
-                    end
-                    |> then(fn result ->
-                      result
-                      |> AshAi.Serializer.serialize_value(Ash.Type.Boolean, [], domain)
-                      |> Jason.encode!()
-                      |> then(&{:ok, &1, result})
-                    end)
-
-                  %{"aggregate" => aggregate_kind} = aggregate ->
-                    if aggregate_kind not in ["min", "max", "sum", "avg", "count"] do
-                      raise "invalid aggregate function"
-                    end
-
-                    if !aggregate["field"] do
-                      raise "missing field argument"
-                    end
-
-                    field = Ash.Resource.Info.field(resource, aggregate["field"])
-
-                    if !field || !field.public? do
-                      raise "no such field"
-                    end
-
-                    aggregate_kind = String.to_existing_atom(aggregate_kind)
-
-                    aggregate =
-                      Ash.Query.Aggregate.new!(resource, :aggregate_result, aggregate_kind,
-                        field: field.name
-                      )
-
-                    query
-                    |> Ash.aggregate(aggregate)
-                    |> case do
-                      {:ok, value} ->
-                        value
-
-                      {:error, error} ->
-                        raise Ash.Error.to_error_class(error)
-                    end
-                    |> then(fn result ->
-                      result
-                      |> AshAi.Serializer.serialize_value(
-                        aggregate.type,
-                        aggregate.constraints,
-                        domain
-                      )
-                      |> Jason.encode!()
-                      |> then(&{:ok, &1, result})
-                    end)
-                end
-              end)
-
-            :update ->
-              filter = identity_filter(identity, resource, arguments)
-
-              resource
-              |> Ash.Query.do_filter(filter)
-              |> Ash.Query.limit(1)
-              |> Ash.bulk_update!(
-                action.name,
-                input,
-                Keyword.merge(opts,
-                  return_errors?: true,
-                  notify?: true,
-                  strategy: [:atomic, :stream, :atomic_batches],
-                  load: load,
-                  allow_stream_with: :full_read,
-                  return_records?: true
-                )
-              )
-              |> case do
-                %Ash.BulkResult{status: :success, records: [result]} ->
-                  result
-                  |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
-                  |> Jason.encode!()
-                  |> then(&{:ok, &1, result})
-
-                %Ash.BulkResult{status: :success, records: []} ->
-                  raise Ash.Error.to_error_class(
-                          Ash.Error.Query.NotFound.exception(primary_key: filter)
-                        )
-              end
-
-            :destroy ->
-              filter = identity_filter(identity, resource, arguments)
-
-              resource
-              |> Ash.Query.do_filter(filter)
-              |> Ash.Query.limit(1)
-              |> Ash.bulk_destroy!(
-                action.name,
-                input,
-                Keyword.merge(opts,
-                  return_errors?: true,
-                  notify?: true,
-                  load: load,
-                  strategy: [:atomic, :stream, :atomic_batches],
-                  allow_stream_with: :full_read,
-                  return_records?: true
-                )
-              )
-              |> case do
-                %Ash.BulkResult{status: :success, records: [result]} ->
-                  result
-                  |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
-                  |> Jason.encode!()
-                  |> then(&{:ok, &1, result})
-
-                %Ash.BulkResult{status: :success, records: []} ->
-                  raise Ash.Error.to_error_class(
-                          Ash.Error.Query.NotFound.exception(primary_key: filter)
-                        )
-              end
-
-            :create ->
-              resource
-              |> Ash.Changeset.for_create(action.name, input, opts)
-              |> Ash.create!(load: load)
-              |> then(fn result ->
-                result
-                |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
-                |> Jason.encode!()
-                |> then(&{:ok, &1, result})
-              end)
-
-            :action ->
-              resource
-              |> Ash.ActionInput.for_action(action.name, input, opts)
-              |> Ash.run_action!()
-              |> then(fn result ->
-                if action.returns do
-                  result
-                  |> AshAi.Serializer.serialize_value(action.returns, [], domain, load: load)
-                  |> Jason.encode!()
-                else
-                  "success"
-                end
-                |> then(&{:ok, &1, result})
-              end)
-          end
-        rescue
-          error ->
-            error = Ash.Error.to_error_class(error)
-
-            {:error,
-             domain
-             |> AshJsonApi.Error.to_json_api_errors(resource, error, action.type)
-             |> serialize_errors()
-             |> Jason.encode!()}
+        if on_start = callbacks[:on_tool_start] do
+          on_start.(%ToolStartEvent{
+            tool_name: name,
+            action: action.name,
+            resource: resource,
+            arguments: arguments,
+            actor: actor,
+            tenant: tenant
+          })
         end
+
+        result =
+          try do
+            case action.type do
+              :read ->
+                sort =
+                  case arguments["sort"] do
+                    sort when is_list(sort) ->
+                      Enum.map(sort, fn map ->
+                        case map["direction"] || "asc" do
+                          "asc" -> map["field"]
+                          "desc" -> "-#{map["field"]}"
+                        end
+                      end)
+
+                    nil ->
+                      []
+                  end
+                  |> Enum.join(",")
+
+                resource
+                |> Ash.Query.limit(arguments["limit"] || 25)
+                |> Ash.Query.offset(arguments["offset"])
+                |> then(fn query ->
+                  if sort != "" do
+                    Ash.Query.sort_input(query, sort)
+                  else
+                    query
+                  end
+                end)
+                |> then(fn query ->
+                  if Map.has_key?(arguments, "filter") do
+                    Ash.Query.filter_input(query, arguments["filter"])
+                  else
+                    query
+                  end
+                end)
+                |> Ash.Query.for_read(action.name, input, opts)
+                |> then(fn query ->
+                  result_type = arguments["result_type"] || "run_query"
+
+                  case result_type do
+                    "run_query" ->
+                      query
+                      |> Ash.Actions.Read.unpaginated_read(action, load: load)
+                      |> case do
+                        {:ok, value} ->
+                          value
+
+                        {:error, error} ->
+                          raise Ash.Error.to_error_class(error)
+                      end
+                      |> then(fn result ->
+                        result
+                        |> AshAi.Serializer.serialize_value({:array, resource}, [], domain,
+                          load: load
+                        )
+                        |> Jason.encode!()
+                        |> then(&{:ok, &1, result})
+                      end)
+
+                    "count" ->
+                      query
+                      |> Ash.count()
+                      |> case do
+                        {:ok, value} ->
+                          value
+
+                        {:error, error} ->
+                          raise Ash.Error.to_error_class(error)
+                      end
+                      |> then(fn result ->
+                        result
+                        |> AshAi.Serializer.serialize_value(Ash.Type.Integer, [], domain)
+                        |> Jason.encode!()
+                        |> then(&{:ok, &1, result})
+                      end)
+
+                    "exists" ->
+                      query
+                      |> Ash.exists()
+                      |> case do
+                        {:ok, value} ->
+                          value
+
+                        {:error, error} ->
+                          raise Ash.Error.to_error_class(error)
+                      end
+                      |> then(fn result ->
+                        result
+                        |> AshAi.Serializer.serialize_value(Ash.Type.Boolean, [], domain)
+                        |> Jason.encode!()
+                        |> then(&{:ok, &1, result})
+                      end)
+
+                    %{"aggregate" => aggregate_kind} = aggregate ->
+                      if aggregate_kind not in ["min", "max", "sum", "avg", "count"] do
+                        raise "invalid aggregate function"
+                      end
+
+                      if !aggregate["field"] do
+                        raise "missing field argument"
+                      end
+
+                      field = Ash.Resource.Info.field(resource, aggregate["field"])
+
+                      if !field || !field.public? do
+                        raise "no such field"
+                      end
+
+                      aggregate_kind = String.to_existing_atom(aggregate_kind)
+
+                      aggregate =
+                        Ash.Query.Aggregate.new!(resource, :aggregate_result, aggregate_kind,
+                          field: field.name
+                        )
+
+                      query
+                      |> Ash.aggregate(aggregate)
+                      |> case do
+                        {:ok, value} ->
+                          value
+
+                        {:error, error} ->
+                          raise Ash.Error.to_error_class(error)
+                      end
+                      |> then(fn result ->
+                        result
+                        |> AshAi.Serializer.serialize_value(
+                          aggregate.type,
+                          aggregate.constraints,
+                          domain
+                        )
+                        |> Jason.encode!()
+                        |> then(&{:ok, &1, result})
+                      end)
+                  end
+                end)
+
+              :update ->
+                filter = identity_filter(identity, resource, arguments)
+
+                resource
+                |> Ash.Query.do_filter(filter)
+                |> Ash.Query.limit(1)
+                |> Ash.bulk_update!(
+                  action.name,
+                  input,
+                  Keyword.merge(opts,
+                    return_errors?: true,
+                    notify?: true,
+                    strategy: [:atomic, :stream, :atomic_batches],
+                    load: load,
+                    allow_stream_with: :full_read,
+                    return_records?: true
+                  )
+                )
+                |> case do
+                  %Ash.BulkResult{status: :success, records: [result]} ->
+                    result
+                    |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
+                    |> Jason.encode!()
+                    |> then(&{:ok, &1, result})
+
+                  %Ash.BulkResult{status: :success, records: []} ->
+                    raise Ash.Error.to_error_class(
+                            Ash.Error.Query.NotFound.exception(primary_key: filter)
+                          )
+                end
+
+              :destroy ->
+                filter = identity_filter(identity, resource, arguments)
+
+                resource
+                |> Ash.Query.do_filter(filter)
+                |> Ash.Query.limit(1)
+                |> Ash.bulk_destroy!(
+                  action.name,
+                  input,
+                  Keyword.merge(opts,
+                    return_errors?: true,
+                    notify?: true,
+                    load: load,
+                    strategy: [:atomic, :stream, :atomic_batches],
+                    allow_stream_with: :full_read,
+                    return_records?: true
+                  )
+                )
+                |> case do
+                  %Ash.BulkResult{status: :success, records: [result]} ->
+                    result
+                    |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
+                    |> Jason.encode!()
+                    |> then(&{:ok, &1, result})
+
+                  %Ash.BulkResult{status: :success, records: []} ->
+                    raise Ash.Error.to_error_class(
+                            Ash.Error.Query.NotFound.exception(primary_key: filter)
+                          )
+                end
+
+              :create ->
+                resource
+                |> Ash.Changeset.for_create(action.name, input, opts)
+                |> Ash.create!(load: load)
+                |> then(fn result ->
+                  result
+                  |> AshAi.Serializer.serialize_value(resource, [], domain, load: load)
+                  |> Jason.encode!()
+                  |> then(&{:ok, &1, result})
+                end)
+
+              :action ->
+                resource
+                |> Ash.ActionInput.for_action(action.name, input, opts)
+                |> Ash.run_action!()
+                |> then(fn result ->
+                  if action.returns do
+                    result
+                    |> AshAi.Serializer.serialize_value(action.returns, [], domain, load: load)
+                    |> Jason.encode!()
+                  else
+                    "success"
+                  end
+                  |> then(&{:ok, &1, result})
+                end)
+            end
+          rescue
+            error ->
+              error = Ash.Error.to_error_class(error)
+
+              {:error,
+               domain
+               |> AshJsonApi.Error.to_json_api_errors(resource, error, action.type)
+               |> serialize_errors()
+               |> Jason.encode!()}
+          end
+
+        if on_end = callbacks[:on_tool_end] do
+          on_end.(%ToolEndEvent{
+            tool_name: name,
+            result: result
+          })
+        end
+
+        result
       end
     })
   end

--- a/test/ash_ai/tool_callbacks_test.exs
+++ b/test/ash_ai/tool_callbacks_test.exs
@@ -1,0 +1,656 @@
+defmodule AshAi.ToolCallbacksTest do
+  use ExUnit.Case, async: true
+  alias AshAi.ChatFaker
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Message
+  alias __MODULE__.{TestDomain, TestResource}
+
+  defmodule TestResource do
+    use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :name, :string, public?: true, allow_nil?: false
+      attribute :status, :string, public?: true
+    end
+
+    actions do
+      defaults [:read, :create, :update, :destroy]
+      default_accept [:id, :name, :status]
+
+      action :custom_action, :string do
+        argument :message, :string, allow_nil?: false
+
+        run fn input, _context ->
+          {:ok, "Processed: #{input.arguments.message}"}
+        end
+      end
+    end
+  end
+
+  defmodule TestDomain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource TestResource
+    end
+
+    tools do
+      tool :read_test_resources, TestResource, :read
+      tool :create_test_resource, TestResource, :create
+      tool :update_test_resource, TestResource, :update
+      tool :destroy_test_resource, TestResource, :destroy
+      tool :custom_test_action, TestResource, :custom_action
+    end
+  end
+
+  describe "on_tool_start callback" do
+    test "called with correct parameters for read action" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{"limit" => 10},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, %AshAi.ToolStartEvent{} = event}
+      assert event.tool_name == "read_test_resources"
+      assert event.action == :read
+      assert event.resource == TestResource
+      assert event.arguments == %{"limit" => 10}
+      assert is_nil(event.actor)
+      assert is_nil(event.tenant)
+    end
+
+    test "includes actor and tenant when provided" do
+      test_pid = self()
+      actor = %{id: "user_123"}
+      tenant = "tenant_456"
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          actor: actor,
+          tenant: tenant,
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, event}
+      assert event.actor == actor
+      assert event.tenant == tenant
+    end
+
+    test "called for create action" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "create_test_resource",
+        arguments: %{"input" => %{"name" => "Test Item"}},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, event}
+      assert event.tool_name == "create_test_resource"
+      assert event.action == :create
+      assert event.arguments == %{"input" => %{"name" => "Test Item"}}
+    end
+  end
+
+  describe "on_tool_end callback" do
+    test "called with success result for read action" do
+      test_pid = self()
+
+      # Create a resource for the test
+      {:ok, _resource} =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{name: "Test Item", status: "active"})
+        |> Ash.create(domain: TestDomain)
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_end, %AshAi.ToolEndEvent{} = event}
+      assert event.tool_name == "read_test_resources"
+      assert {:ok, json_result, _raw_result} = event.result
+      assert is_binary(json_result)
+      assert {:ok, decoded} = Jason.decode(json_result)
+      assert is_list(decoded)
+      assert length(decoded) > 0
+    end
+
+    test "called with error result for invalid input" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "create_test_resource",
+        # Missing required name
+        arguments: %{"input" => %{}},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_end, %AshAi.ToolEndEvent{} = event}
+      assert event.tool_name == "create_test_resource"
+      assert {:error, error_json} = event.result
+      assert is_binary(error_json)
+      assert {:ok, errors} = Jason.decode(error_json)
+      assert is_list(errors)
+    end
+
+    test "called for destroy action" do
+      test_pid = self()
+
+      # First create a resource to destroy
+      {:ok, resource} =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{name: "To Delete"})
+        |> Ash.create(domain: TestDomain)
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "destroy_test_resource",
+        arguments: %{"id" => resource.id},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_end, event}
+      assert event.tool_name == "destroy_test_resource"
+      assert {:ok, json_result, _raw_result} = event.result
+      assert is_binary(json_result)
+      # Verify the resource was actually deleted
+      resources = Ash.read!(TestResource, domain: TestDomain)
+      refute Enum.find(resources, &(&1.id == resource.id))
+    end
+
+    test "called for custom action" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "custom_test_action",
+        arguments: %{"input" => %{"message" => "Hello"}},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_end, event}
+      assert event.tool_name == "custom_test_action"
+      assert {:ok, json_result, _raw_result} = event.result
+      assert json_result == "\"Processed: Hello\""
+    end
+  end
+
+  describe "both callbacks together" do
+    test "called in sequence" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event, System.monotonic_time()})
+          end,
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event, System.monotonic_time()})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, %AshAi.ToolStartEvent{} = start_event, start_time}
+      assert_receive {:tool_end, %AshAi.ToolEndEvent{} = end_event, end_time}
+
+      assert start_event.tool_name == end_event.tool_name
+      assert start_time < end_time
+    end
+
+    test "called for destroy action in sequence" do
+      test_pid = self()
+
+      {:ok, resource} =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{name: "To Delete", status: "active"})
+        |> Ash.create(domain: TestDomain)
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "destroy_test_resource",
+        arguments: %{"id" => resource.id},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end,
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, start_event}
+      assert_receive {:tool_end, end_event}
+
+      assert start_event.tool_name == "destroy_test_resource"
+      assert start_event.action == :destroy
+      assert start_event.arguments == %{"id" => resource.id}
+      assert end_event.tool_name == "destroy_test_resource"
+      assert elem(end_event.result, 0) == :ok
+    end
+
+    test "handle tool execution with invalid filter" do
+      test_pid = self()
+
+      # Use an invalid filter to cause an error
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{"filter" => %{"invalid_field" => "value"}},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end,
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, _}
+      assert_receive {:tool_end, end_event}
+      assert {:error, _} = end_event.result
+    end
+  end
+
+  describe "backward compatibility" do
+    test "tools work without any callbacks" do
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain = chain()
+
+      assert {:ok, chain} = run_chain(chain, tool_call)
+
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      assert tool_result.name == "read_test_resources"
+      assert tool_result.type == :function
+      assert is_binary(tool_result.content)
+    end
+
+    test "actor passed without callbacks still sets context" do
+      actor = %{id: "user_123"}
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "create_test_resource",
+        arguments: %{"input" => %{"name" => "Test with Actor"}},
+        index: 0
+      }
+
+      chain = chain(actor: actor)
+
+      # Should work normally without callbacks but with actor
+      assert {:ok, chain} = run_chain(chain, tool_call)
+
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      assert tool_result.name == "create_test_resource"
+      assert tool_result.content =~ "Test with Actor"
+    end
+
+    test "handles nil callbacks in custom context" do
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      # Manually create chain with nil tool_callbacks to test the || %{} fallback
+      chain =
+        %{llm: ChatFaker.new!(%{})}
+        |> LLMChain.new!()
+        |> AshAi.setup_ash_ai(actions: [{TestResource, [:read]}])
+        |> LLMChain.update_custom_context(%{tool_callbacks: nil})
+
+      # Should handle nil callbacks gracefully
+      assert {:ok, chain} = run_chain(chain, tool_call)
+
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      assert tool_result.name == "read_test_resources"
+      assert is_binary(tool_result.content)
+    end
+
+    test "only on_tool_start callback works" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      assert_receive {:tool_start, _}
+      refute_receive {:tool_end, _}
+    end
+
+    test "only on_tool_end callback works" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_end: fn event ->
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      {:ok, _chain} = run_chain(chain, tool_call)
+
+      refute_receive {:tool_start, _}
+      assert_receive {:tool_end, _}
+    end
+  end
+
+  describe "multiple tools execution" do
+    test "callbacks called for each tool" do
+      test_pid = self()
+      call_count = :counters.new(2, [])
+
+      {:ok, resource} =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{
+          id: "0197b375-4daa-7112-a9d8-7f0104485646",
+          name: "Initial",
+          status: "pending"
+        })
+        |> Ash.create(domain: TestDomain)
+
+      tool_calls = [
+        %LangChain.Message.ToolCall{
+          status: :complete,
+          type: :function,
+          call_id: "call_1",
+          name: "read_test_resources",
+          arguments: %{},
+          index: 0
+        },
+        %LangChain.Message.ToolCall{
+          status: :complete,
+          type: :function,
+          call_id: "call_2",
+          name: "update_test_resource",
+          arguments: %{
+            "id" => resource.id,
+            "input" => %{"status" => "active"}
+          },
+          index: 1
+        }
+      ]
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            :counters.add(call_count, 1, 1)
+            send(test_pid, {:tool_start, event})
+          end,
+          on_tool_end: fn event ->
+            :counters.add(call_count, 2, 1)
+            send(test_pid, {:tool_end, event})
+          end
+        )
+
+      chain
+      |> LLMChain.add_message(
+        Message.new_assistant!(%{status: :complete, tool_calls: tool_calls})
+      )
+      |> LLMChain.run(mode: :while_needs_response)
+
+      assert :counters.get(call_count, 1) == 2
+      assert :counters.get(call_count, 2) == 2
+
+      assert_receive {:tool_start, %{tool_name: "read_test_resources"}}
+      assert_receive {:tool_start, %{tool_name: "update_test_resource"}}
+      assert_receive {:tool_end, %{tool_name: "read_test_resources"}}
+      assert_receive {:tool_end, %{tool_name: "update_test_resource"}}
+    end
+  end
+
+  describe "callback error handling" do
+    test "on_tool_start exceptions propagate" do
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn _event ->
+            raise "Callback error"
+          end
+        )
+
+      # Tool execution should fail due to callback error
+      {:ok, chain} = run_chain(chain, tool_call)
+
+      # Verify tool failed
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      assert tool_result.name == "read_test_resources"
+      assert tool_result.content =~ "Callback error"
+    end
+
+    test "on_tool_end exceptions propagate" do
+      test_pid = self()
+
+      tool_call = %LangChain.Message.ToolCall{
+        status: :complete,
+        type: :function,
+        call_id: "call_id",
+        name: "read_test_resources",
+        arguments: %{},
+        index: 0
+      }
+
+      chain =
+        chain(
+          on_tool_start: fn event ->
+            send(test_pid, {:tool_start_called, event})
+          end,
+          on_tool_end: fn _event ->
+            raise "End callback error"
+          end
+        )
+
+      # Tool execution should fail due to callback error
+      {:ok, chain} = run_chain(chain, tool_call)
+
+      # Verify on_tool_start was called
+      assert_receive {:tool_start_called, _}
+
+      # Verify tool failed
+      tool_result =
+        chain.messages
+        |> Enum.find(&(is_nil(&1.tool_results) == false))
+        |> Map.get(:tool_results)
+        |> Enum.at(0)
+
+      assert tool_result.name == "read_test_resources"
+      assert tool_result.content =~ "End callback error"
+    end
+
+  end
+
+  defp chain(opts \\ []) do
+    actions =
+      AshAi.Info.tools(TestDomain)
+      |> Enum.group_by(& &1.resource, & &1.action)
+      |> Map.to_list()
+
+    %{llm: ChatFaker.new!(%{})}
+    |> LLMChain.new!()
+    |> AshAi.setup_ash_ai(Keyword.merge([actions: actions], opts))
+  end
+
+  defp run_chain(chain, tool_call) do
+    chain
+    |> LLMChain.add_message(Message.new_assistant!(%{status: :complete, tool_calls: [tool_call]}))
+    |> LLMChain.run(mode: :while_needs_response)
+  end
+end

--- a/test/ash_ai/tool_callbacks_test.exs
+++ b/test/ash_ai/tool_callbacks_test.exs
@@ -137,7 +137,6 @@ defmodule AshAi.ToolCallbacksTest do
     test "called with success result for read action" do
       test_pid = self()
 
-      # Create a resource for the test
       {:ok, _resource} =
         TestResource
         |> Ash.Changeset.for_create(:create, %{name: "Test Item", status: "active"})
@@ -178,7 +177,6 @@ defmodule AshAi.ToolCallbacksTest do
         type: :function,
         call_id: "call_id",
         name: "create_test_resource",
-        # Missing required name
         arguments: %{"input" => %{}},
         index: 0
       }
@@ -203,7 +201,6 @@ defmodule AshAi.ToolCallbacksTest do
     test "called for destroy action" do
       test_pid = self()
 
-      # First create a resource to destroy
       {:ok, resource} =
         TestResource
         |> Ash.Changeset.for_create(:create, %{name: "To Delete"})
@@ -231,7 +228,6 @@ defmodule AshAi.ToolCallbacksTest do
       assert event.tool_name == "destroy_test_resource"
       assert {:ok, json_result, _raw_result} = event.result
       assert is_binary(json_result)
-      # Verify the resource was actually deleted
       resources = Ash.read!(TestResource, domain: TestDomain)
       refute Enum.find(resources, &(&1.id == resource.id))
     end
@@ -338,7 +334,6 @@ defmodule AshAi.ToolCallbacksTest do
     test "handle tool execution with invalid filter" do
       test_pid = self()
 
-      # Use an invalid filter to cause an error
       tool_call = %LangChain.Message.ToolCall{
         status: :complete,
         type: :function,
@@ -406,7 +401,6 @@ defmodule AshAi.ToolCallbacksTest do
 
       chain = chain(actor: actor)
 
-      # Should work normally without callbacks but with actor
       assert {:ok, chain} = run_chain(chain, tool_call)
 
       tool_result =
@@ -429,14 +423,13 @@ defmodule AshAi.ToolCallbacksTest do
         index: 0
       }
 
-      # Manually create chain with nil tool_callbacks to test the || %{} fallback
+      # Tests the || %{} fallback
       chain =
         %{llm: ChatFaker.new!(%{})}
         |> LLMChain.new!()
         |> AshAi.setup_ash_ai(actions: [{TestResource, [:read]}])
         |> LLMChain.update_custom_context(%{tool_callbacks: nil})
 
-      # Should handle nil callbacks gracefully
       assert {:ok, chain} = run_chain(chain, tool_call)
 
       tool_result =
@@ -582,10 +575,8 @@ defmodule AshAi.ToolCallbacksTest do
           end
         )
 
-      # Tool execution should fail due to callback error
       {:ok, chain} = run_chain(chain, tool_call)
 
-      # Verify tool failed
       tool_result =
         chain.messages
         |> Enum.find(&(is_nil(&1.tool_results) == false))
@@ -618,13 +609,10 @@ defmodule AshAi.ToolCallbacksTest do
           end
         )
 
-      # Tool execution should fail due to callback error
       {:ok, chain} = run_chain(chain, tool_call)
 
-      # Verify on_tool_start was called
       assert_receive {:tool_start_called, _}
 
-      # Verify tool failed
       tool_result =
         chain.messages
         |> Enum.find(&(is_nil(&1.tool_results) == false))

--- a/test/ash_ai/tool_callbacks_test.exs
+++ b/test/ash_ai/tool_callbacks_test.exs
@@ -622,7 +622,6 @@ defmodule AshAi.ToolCallbacksTest do
       assert tool_result.name == "read_test_resources"
       assert tool_result.content =~ "End callback error"
     end
-
   end
 
   defp chain(opts \\ []) do


### PR DESCRIPTION
Adds the `on_tool_start` and `on_tool_end` callbacks to `setup_ash_ai/2`. I initially planned on only adding `on_tool_start` but decided to also add `on_tool_end` for consistency. [on_tool_response_created](https://hexdocs.pm/langchain/changelog.html#added-1:~:text=on_tool_response_created) is available via langchain but it's a recent addition and not well documented.

Fixes https://github.com/ash-project/ash_ai/issues/91. 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
