### PR TITLE
Add case for ChatGoogleAI

### DIFF
--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -275,6 +275,9 @@ defmodule AshAi.Actions.Prompt do
           %LangChain.ChatModels.ChatAnthropic{} ->
             AshAi.Actions.Prompt.Adapter.CompletionTool
 
+          %LangChain.ChatModels.ChatGoogleAI{} ->
+            AshAi.Actions.Prompt.Adapter.RequestJson
+
           _ ->
             raise """
             No default adapter found for the given LLM.


### PR DESCRIPTION
I was playing with different LLM models and I saw that there's no adapter declared for Google's Gemini models. After adding `AshAi.Actions.Prompt.Adapter.RequestJson` I noticed that it seemed to be able to return responses into typed structs as I'd expect based on the information in the documentation [here](https://hexdocs.pm/ash_ai/readme.html#using-custom-types-for-structured-outputs).

I didn't see test cases for this particular functionality so I did not tweak the test suite.

Please let me know if I'm missing something, or if you'd prefer I tackle this another way.

Thanks for considering it!

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I ran `mix check` and it seems to have run successfully.