### PR TITLE
fix: eliminate chat_live compile warning

### DIFF
--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -1097,9 +1097,9 @@ if Code.ensure_loaded?(Igniter) do
 
             <div class="drawer-side border-r bg-base-300 min-w-72">
               <div class="py-4 px-6">
-                <.header class="text-lg mb-4">
+                <div class="text-lg mb-4">
                   Conversations
-                </.header>
+                </div>
                 <div class="mb-4">
                   <.link navigate={~p"/chat"} class="btn btn-primary btn-lg mb-2">
                     <div class="rounded-full bg-primary-content text-primary w-6 h-6 flex items-center justify-center">


### PR DESCRIPTION
Currently, when compiling the generated 'chat_live' module, a warning is emitted: `warning: undefined attribute "class" for component MyAppWeb.CoreComponents.header/1`

This fix simply changes `.header` to `div`

This PR fixes #106 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
