### PR TITLE
Respect resource pagination limits

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -472,8 +472,28 @@ defmodule AshAi do
                   end
                   |> Enum.join(",")
 
+                limit =
+                  case {arguments["limit"], action.pagination} do
+                    {limit, false} when is_integer(limit) ->
+                      limit
+
+                    {limit,
+                     %Ash.Resource.Actions.Read.Pagination{
+                       default_limit: default,
+                       max_page_size: max
+                     }} ->
+                      cond do
+                        is_integer(limit) and is_integer(max) -> min(limit, max)
+                        is_nil(limit) and is_integer(default) -> default
+                        true -> 25
+                      end
+
+                    _ ->
+                      25
+                  end
+
                 resource
-                |> Ash.Query.limit(arguments["limit"] || 25)
+                |> Ash.Query.limit(limit)
                 |> Ash.Query.offset(arguments["offset"])
                 |> then(fn query ->
                   if sort != "" do
@@ -958,10 +978,14 @@ defmodule AshAi do
       limit: %{
         type: :integer,
         description: "The maximum number of records to return",
-        default: case pagination do
-          %Ash.Resource.Actions.Read.Pagination{default_limit: limit} when is_integer(limit) -> limit
-          _ -> 25
-        end
+        default:
+          case pagination do
+            %Ash.Resource.Actions.Read.Pagination{default_limit: limit} when is_integer(limit) ->
+              limit
+
+            _ ->
+              25
+          end
       },
       offset: %{
         type: :integer,


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

- When advertising available tools on `tools/list`, list the default page limit of the resource or 25 if not set.
- When executing a read query, if the client has requested a limit, clamp it to the resource pagination's max page size. If the client has not requested a limit, use the default for the resource. If no pagination is configured for the resource and the client has not requested a limit, use 25.
- When running a count query, unset the limit and offset from the query, otherwise `Ash.count()` will always return 25 if you have more than 25 records in your resource. This change *should* be safe if you have an access policy it will automatically add a filter to your query.