### PR TITLE
Fix BadMapError when LangChain/MCP calls tools without arguments

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -485,7 +485,7 @@ defmodule AshAi do
             case action.type do
               :read ->
                 sort =
-                  case arguments && arguments["sort"] do
+                  case arguments["sort"] do
                     sort when is_list(sort) ->
                       Enum.map(sort, fn map ->
                         case map["direction"] || "asc" do
@@ -500,7 +500,7 @@ defmodule AshAi do
                   |> Enum.join(",")
 
                 limit =
-                  case {arguments && arguments["limit"], action.pagination} do
+                  case {arguments["limit"], action.pagination} do
                     {limit, false} when is_integer(limit) ->
                       limit
 
@@ -521,7 +521,7 @@ defmodule AshAi do
 
                 resource
                 |> Ash.Query.limit(limit)
-                |> Ash.Query.offset(arguments && arguments["offset"])
+                |> Ash.Query.offset(arguments["offset"])
                 |> then(fn query ->
                   if sort != "" do
                     Ash.Query.sort_input(query, sort)


### PR DESCRIPTION
This fixes a critical issue where AshAi crashes with `BadMapError: expected a map, got: nil` when LangChain or MCP clients call tools without providing arguments.

Some LangChain/MCP implementations send `nil` instead of an empty object `{}` when calling tools that have no required parameters. This causes AshAi to fail when trying to access properties like `arguments["filter"]`.

Changes:
- Added nil-safety check at the beginning of the tool function (arguments = arguments || %{})
- Updated all argument property accesses to safely handle nil values
- Added test case to verify tools can be called with nil arguments

Impact:
- Fixes crashes for tools with no required arguments
- Improves compatibility with various LangChain/MCP client implementations
- No breaking changes - existing code continues to work as before

Fixes the issue where tools fail with:
** (BadMapError) expected a map, got: nil

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
