### PR TITLE
Fix ash_ai.gen.chat to validate text presence in messages

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -461,7 +461,7 @@ defmodule AshAi do
       function: fn arguments, context ->
         # Handle nil arguments from LangChain/MCP clients
         arguments = arguments || %{}
-        
+
         actor = context[:actor]
         tenant = context[:tenant]
         input = arguments["input"] || %{}

--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -360,6 +360,9 @@ if Code.ensure_loaded?(Igniter) do
       |> Ash.Resource.Igniter.add_new_action(message, :create, """
       create :create do
         accept [:text]
+        validate match(:text, ~r/\\S/) do
+          message "Message cannot be empty"
+        end
         argument :conversation_id, :uuid do
           public? false
         end

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -87,7 +87,8 @@ defmodule AshAi.ToolTest do
         type: :function,
         call_id: "call_id",
         name: "read_test_resources",
-        arguments: nil,  # This is what some LangChain/MCP clients send
+        # This is what some LangChain/MCP clients send
+        arguments: nil,
         index: 0
       }
 


### PR DESCRIPTION
- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.

# Summary

When playing with `ash_ai.gen.chat` to understand how to use Ash AI in my app, I stumbled upon the problem that in the generated code, a single message with empty content or just a white-space character would stop the conversation from working. Despite not being a big problem, I stumbled upon it during testing, thinking I did something wrong during configuration, so I figured it might make sense to add a small validation.

### Problem

A single message with empty content or just white space in the message chain causes an `LangChain.LangChainError`.

### Solution

A simple validation testing for non-whitespace characters in the action used to generate the user messages.

```
validate match(:text, ~r/\S/) do
  message "Message cannot be empty"
end
```

I did not just add a `present` validation, to also avoid white space characters.

### Impact

Empty messages will not be created upon submission of the form. Since the `respond` change uses another action, the llm / agent can still store a message without content when it starts streaming a tool call.

### Testing

The change did not affect any tests. Since the test suite resulted in a formatter and a credo issue, I added a second commit to fix these two. `mix check` passes now.
