### PR TITLE
Adapt Prompt adapters for upcoming LangChain 0.4 release

### DIFF
--- a/lib/ash_ai/actions/prompt/adapter/raw.ex
+++ b/lib/ash_ai/actions/prompt/adapter/raw.ex
@@ -11,6 +11,7 @@ defmodule AshAi.Actions.Prompt.Adapter.Raw do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
+  alias LangChain.Message.ContentPart
 
   def run(%Data{} = data, _opts) do
     %{
@@ -23,10 +24,11 @@ defmodule AshAi.Actions.Prompt.Adapter.Raw do
     |> LLMChain.add_tools(data.tools)
     |> LLMChain.run(mode: :while_needs_response)
     |> case do
-      {:ok,
-       %LangChain.Chains.LLMChain{
-         last_message: %{content: content}
-       }}
+      {:ok, %LLMChain{last_message: %{content: content}}}
+      when is_binary(content) ->
+        process_llm_response(content, data)
+
+      {:ok, %LLMChain{last_message: %{content: [%ContentPart{type: :text, content: content}]}}}
       when is_binary(content) ->
         process_llm_response(content, data)
 


### PR DESCRIPTION
With the new RC for LangChain 0.4, the content of a message is always a list of at least one contentpart.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
