### PR TITLE
Support LangChain 0.4

### DIFF
--- a/lib/ash_ai/actions/prompt/adapter/raw.ex
+++ b/lib/ash_ai/actions/prompt/adapter/raw.ex
@@ -11,6 +11,7 @@ defmodule AshAi.Actions.Prompt.Adapter.Raw do
 
   alias AshAi.Actions.Prompt.Adapter.Data
   alias LangChain.Chains.LLMChain
+  alias LangChain.Message.ContentPart
 
   def run(%Data{} = data, _opts) do
     %{
@@ -23,10 +24,11 @@ defmodule AshAi.Actions.Prompt.Adapter.Raw do
     |> LLMChain.add_tools(data.tools)
     |> LLMChain.run(mode: :while_needs_response)
     |> case do
-      {:ok,
-       %LangChain.Chains.LLMChain{
-         last_message: %{content: content}
-       }}
+      {:ok, %LLMChain{last_message: %{content: content}}}
+      when is_binary(content) ->
+        process_llm_response(content, data)
+
+      {:ok, %LLMChain{last_message: %{content: [%ContentPart{type: :text, content: content}]}}}
       when is_binary(content) ->
         process_llm_response(content, data)
 

--- a/test/ash_ai/tool_callbacks_test.exs
+++ b/test/ash_ai/tool_callbacks_test.exs
@@ -1,5 +1,6 @@
 defmodule AshAi.ToolCallbacksTest do
   use ExUnit.Case, async: true
+  import AshAi.Test.LangChainHelpers
   alias AshAi.ChatFaker
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
@@ -384,7 +385,10 @@ defmodule AshAi.ToolCallbacksTest do
 
       assert tool_result.name == "read_test_resources"
       assert tool_result.type == :function
-      assert is_binary(tool_result.content)
+
+      # Content should be extractable as text (backward compatible with both string and ContentPart formats)
+      assert {:ok, text} = extract_content_text(tool_result.content)
+      assert is_binary(text)
     end
 
     test "actor passed without callbacks still sets context" do
@@ -410,7 +414,8 @@ defmodule AshAi.ToolCallbacksTest do
         |> Enum.at(0)
 
       assert tool_result.name == "create_test_resource"
-      assert tool_result.content =~ "Test with Actor"
+      assert {:ok, text} = extract_content_text(tool_result.content)
+      assert text =~ "Test with Actor"
     end
 
     test "handles nil callbacks in custom context" do
@@ -439,7 +444,8 @@ defmodule AshAi.ToolCallbacksTest do
         |> Enum.at(0)
 
       assert tool_result.name == "read_test_resources"
-      assert is_binary(tool_result.content)
+      assert {:ok, text} = extract_content_text(tool_result.content)
+      assert is_binary(text)
     end
 
     test "only on_tool_start callback works" do
@@ -584,7 +590,8 @@ defmodule AshAi.ToolCallbacksTest do
         |> Enum.at(0)
 
       assert tool_result.name == "read_test_resources"
-      assert tool_result.content =~ "Callback error"
+      assert {:ok, text} = extract_content_text(tool_result.content)
+      assert text =~ "Callback error"
     end
 
     test "on_tool_end exceptions propagate" do
@@ -620,7 +627,8 @@ defmodule AshAi.ToolCallbacksTest do
         |> Enum.at(0)
 
       assert tool_result.name == "read_test_resources"
-      assert tool_result.content =~ "End callback error"
+      assert {:ok, text} = extract_content_text(tool_result.content)
+      assert text =~ "End callback error"
     end
   end
 

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -1,5 +1,6 @@
 defmodule AshAi.ToolTest do
   use ExUnit.Case, async: true
+  import AshAi.Test.LangChainHelpers
   alias AshAi.ChatFaker
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
@@ -76,7 +77,9 @@ defmodule AshAi.ToolTest do
       # ID is included because it's a primary key
       # Public name and email are included because they're public attributes
       # Internal status is included because it's a loaded field
-      assert tool_result.content ==
+      assert {:ok, text} = extract_content_text(tool_result.content)
+
+      assert text ==
                "[{\"id\":\"0197b375-4daa-7112-a9d8-7f0104485646\",\"public_name\":\"John Doe\",\"public_email\":\"john@example.com\",\"internal_status\":\"classified\"}]"
     end
 
@@ -102,7 +105,9 @@ defmodule AshAi.ToolTest do
         |> Enum.at(0)
 
       # Should return the resource data without crashing
-      assert tool_result.content ==
+      assert {:ok, text} = extract_content_text(tool_result.content)
+
+      assert text ==
                "[{\"id\":\"0197b375-4daa-7112-a9d8-7f0104485646\",\"public_name\":\"John Doe\",\"public_email\":\"john@example.com\",\"internal_status\":\"classified\"}]"
     end
   end

--- a/test/support/langchain_helpers.ex
+++ b/test/support/langchain_helpers.ex
@@ -1,0 +1,23 @@
+defmodule AshAi.Test.LangChainHelpers do
+  @moduledoc """
+  Helper function for handling LangChain version compatibility in tests.
+
+  In LangChain 0.4+, message content became a list of ContentPart structs,
+  while in earlier versions it was a plain string. This helper provides
+  a backward-compatible way to extract text content.
+  """
+
+  alias LangChain.Message.ContentPart
+
+  def extract_content_text([%ContentPart{type: :text, content: text} | _]) when is_binary(text) do
+    {:ok, text}
+  end
+
+  def extract_content_text(content) when is_binary(content) do
+    {:ok, content}
+  end
+
+  def extract_content_text(_content) do
+    :error
+  end
+end


### PR DESCRIPTION
With the upcoming LangChain 0.4 release, the 'content' of messages is always a list of ContentParts. This PR fixes the `prompt()` action runner for those cases and adds a test assertion helper for the changed output format of messages.

Note that locally I updated to `{:langchain, "~> 0.4.0-rc.2"}` and then fixed all the tests. That change obviously cannot be commited to this branch so you'll have to trust me that this works ;-)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
