### PR TITLE
improvement: Replace custom MCP server with Hermes MCP SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 <!-- changelog -->
 
+## [Unreleased]
+
+### Improvements:
+
+* Replace custom MCP server implementation with Hermes MCP SDK
+
 ## [v0.3.0](https://github.com/ash-project/ash_ai/compare/v0.2.14...v0.3.0) (2025-10-28)
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ end
 
 ## MCP (Model Context Protocol) Server
 
+AshAi provides MCP server functionality powered by [Hermes MCP](https://hexdocs.pm/hermes_mcp/),
+a comprehensive Elixir SDK for the Model Context Protocol.
+
 Both the dev & production MCP servers can be installed with
 
 `mix ash_ai.gen.mcp`

--- a/lib/ash_ai/application.ex
+++ b/lib/ash_ai/application.ex
@@ -8,8 +8,15 @@ defmodule AshAi.Application do
 
   @impl true
   def start(_type, _args) do
+    children = [
+      # Hermes Server Registry for MCP servers
+      Hermes.Server.Registry,
+      # Dynamic supervisor for MCP server instances
+      {DynamicSupervisor, name: AshAi.Mcp.DynamicSupervisor, strategy: :one_for_one}
+    ]
+
     Supervisor.start_link(
-      [],
+      children,
       strategy: :one_for_one,
       name: AshAi.Supervisor
     )

--- a/lib/ash_ai/mcp.ex
+++ b/lib/ash_ai/mcp.ex
@@ -4,35 +4,35 @@
 
 defmodule AshAi.Mcp do
   @moduledoc """
-  Model Context Protocol (MCP) implementation for Ash Framework.
+  Model Context Protocol (MCP) implementation for Ash Framework using Hermes MCP.
 
-  This module implements a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server
-  that integrates with Ash Framework, following the MCP [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) specification.
+  This module provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server
+  that integrates with Ash Framework, powered by [Hermes MCP](https://hexdocs.pm/hermes_mcp/).
 
   ## Overview
 
   This MCP implementation provides:
 
-  * A fully compliant MCP server with JSON-RPC message processing
-  * Session management with unique session IDs
-  * Support for both JSON and Server-Sent Events (SSE) responses
-  * Batch request handling
-  * A foundation for integrating Ash resources with MCP clients
-  * Integration with AshAi tools for AI-assisted operations
+  * A fully compliant MCP server powered by Hermes MCP SDK
+  * Support for both JSON and Server-Sent Events (SSE) responses via Streamable HTTP transport
+  * Automatic tool registration from AshAi functions
+  * Integration with Ash resources and authentication
+  * Production-ready server implementation with supervision
 
   ## Current Features
 
-  * `initialize` and `shutdown` method handlers
-  * Session management via GenServer processes
-  * Support for streaming responses
+  * Protocol-compliant initialization and tool handling
+  * Automatic tool discovery from AshAi tool definitions
+  * Actor, tenant, and context support from Ash.PlugHelpers
+  * Dynamic server instance management
   * Plug-compatible router for easy integration
-  * Tool support for AshAi functions
+  * Dev mode support with ash_dev_tools
 
   ## Future Enhancements
 
   * OAuth integration with AshAuthentication
-  * Resource-specific method handlers
-  * Advanced streaming capabilities
+  * Resource and prompt support
+  * Advanced capabilities (sampling, logging, etc.)
 
   ## Integration
 

--- a/lib/ash_ai/mcp/dev.ex
+++ b/lib/ash_ai/mcp/dev.ex
@@ -31,10 +31,9 @@ defmodule AshAi.Mcp.Dev do
     expected_path = Keyword.get(opts, :path)
 
     case Enum.split(path_info, length(expected_path)) do
-      {^expected_path, rest} ->
-        conn
-        |> Plug.forward(rest, AshAi.Mcp.Router, opts)
-        |> Plug.Conn.halt()
+      {^expected_path, _rest} ->
+        # Forward to the router with tools set to ash_dev_tools
+        AshAi.Mcp.Router.call(conn, opts)
 
       _ ->
         conn

--- a/lib/ash_ai/mcp/router.ex
+++ b/lib/ash_ai/mcp/router.ex
@@ -5,7 +5,7 @@
 if Code.ensure_loaded?(Plug) do
   defmodule AshAi.Mcp.Router do
     @moduledoc """
-    MCP Router implementing the RPC functionality over HTTP.
+    MCP Router implementing the RPC functionality over HTTP using Hermes MCP.
 
     This router handles HTTP requests according to the Model Context Protocol specification.
 
@@ -16,48 +16,100 @@ if Code.ensure_loaded?(Plug) do
     ```
     """
 
-    use Plug.Router, copy_opts_to_assign: :router_opts
+    @behaviour Plug
 
-    alias AshAi.Mcp.Server
-
-    # Parse the request body for JSON
-    plug(Plug.Parsers,
-      parsers: [:json],
-      pass: ["application/json"],
-      json_decoder: Jason
-    )
-
-    plug(:match)
-    plug(:dispatch)
-
-    post "/" do
-      session_id = get_session_id(conn)
-
-      Server.handle_post(conn, conn.params, session_id, conn.assigns.router_opts)
+    @impl true
+    def init(opts) do
+      # Validate and store options
+      opts
     end
 
-    get "/" do
-      session_id = get_session_id(conn)
+    @impl true
+    def call(conn, opts) do
+      # Get actor, tenant, and context from connection
+      actor = Ash.PlugHelpers.get_actor(conn)
+      tenant = Ash.PlugHelpers.get_tenant(conn)
+      context = Ash.PlugHelpers.get_context(conn) || %{}
 
-      Server.handle_get(conn, session_id)
+      # Merge connection-specific data with provided options
+      server_opts =
+        opts
+        |> Keyword.put(:actor, actor)
+        |> Keyword.put(:tenant, tenant)
+        |> Keyword.put(:context, context)
+
+      # Generate a unique server name for this configuration
+      # This ensures each endpoint/configuration has its own server instance
+      server_name = server_name_for_opts(server_opts)
+
+      # Ensure server is started
+      case ensure_server_running(server_name, server_opts) do
+        {:ok, _pid} ->
+          # Delegate to Hermes transport handler
+          # Hermes.Transport.StreamableHTTP handles the HTTP/SSE protocol
+          Hermes.Transport.StreamableHTTP.call(conn, server_name)
+
+        {:error, reason} ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(
+            500,
+            Jason.encode!(%{error: "Failed to start MCP server", reason: inspect(reason)})
+          )
+      end
     end
 
-    delete "/" do
-      session_id = get_session_id(conn)
+    # Generate a unique name for the server based on options
+    defp server_name_for_opts(opts) do
+      # Use the otp_app and tools configuration to generate a unique name
+      otp_app = opts[:otp_app] || :ash_ai
+      tools = opts[:tools] || []
 
-      Server.handle_delete(conn, session_id)
+      tools_hash =
+        :erlang.phash2({otp_app, tools})
+        |> Integer.to_string()
+
+      Module.concat([AshAi.Mcp.Server, "Instance#{tools_hash}"])
     end
 
-    # Default route
-    match _ do
-      send_resp(conn, 404, "Not found")
+    # Ensure a server is running with the given name and options
+    defp ensure_server_running(server_name, opts) do
+      case Process.whereis(server_name) do
+        nil ->
+          # Server not running, start it
+          start_server(server_name, opts)
+
+        pid when is_pid(pid) ->
+          # Server already running
+          {:ok, pid}
+      end
     end
 
-    # Helper to extract the session ID from headers
-    defp get_session_id(conn) do
-      case get_req_header(conn, "mcp-session-id") do
-        [session_id | _] -> session_id
-        [] -> nil
+    # Start a new server instance
+    defp start_server(server_name, opts) do
+      child_spec = %{
+        id: server_name,
+        start:
+          {AshAi.Mcp.Server, :start_link,
+           [
+             [
+               name: server_name,
+               transport: :streamable_http,
+               init_options: opts
+             ]
+           ]},
+        restart: :permanent
+      }
+
+      case DynamicSupervisor.start_child(AshAi.Mcp.DynamicSupervisor, child_spec) do
+        {:ok, pid} ->
+          {:ok, pid}
+
+        {:error, {:already_started, pid}} ->
+          {:ok, pid}
+
+        error ->
+          error
       end
     end
   end

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -4,339 +4,100 @@
 
 defmodule AshAi.Mcp.Server do
   @moduledoc """
-  Implementation of the Model Context Protocol (MCP) RPC functionality.
+  Implementation of the Model Context Protocol (MCP) server using Hermes MCP.
 
-  This module handles HTTP requests and responses according to the MCP specification,
-  supporting both synchronous and streaming communication patterns.
-  It also handles the core JSON-RPC message processing for the protocol.
+  This module handles MCP requests according to the MCP specification,
+  integrating with the AshAi tool system to provide AI-assisted operations.
   """
+
+  use Hermes.Server,
+    name: "AshAi MCP Server",
+    version: "0.3.0"
 
   @doc """
-  Process an HTTP POST request containing JSON-RPC messages
+  Initialize the MCP server and register tools.
+
+  This callback is invoked when the MCP client sends an initialize request.
+  We use this to set up our tools based on the provided options.
   """
-  # sobelow_skip ["XSS.SendResp"]
-  def handle_post(conn, body, session_id, opts \\ []) do
-    accept_header = Plug.Conn.get_req_header(conn, "accept")
-    _accept_sse = Enum.any?(accept_header, &String.contains?(&1, "text/event-stream"))
-    _accept_json = Enum.any?(accept_header, &String.contains?(&1, "application/json"))
+  @impl true
+  def init(protocol_options, opts) do
+    # Store opts for later use in handle_tool
+    state = %{
+      opts: opts,
+      protocol_options: protocol_options
+    }
 
-    opts =
-      [
-        actor: Ash.PlugHelpers.get_actor(conn),
-        tenant: Ash.PlugHelpers.get_tenant(conn),
-        context: Ash.PlugHelpers.get_context(conn) || %{}
-      ]
-      |> Keyword.merge(opts)
-
-    case process_request(body, session_id, opts) do
-      {:initialize_response, response, new_session_id} ->
-        # Return the initialize response with a session ID header
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.put_resp_header("mcp-session-id", new_session_id)
-        |> Plug.Conn.send_resp(200, response)
-
-      {:json_response, response, _session_id} ->
-        # Regular JSON response
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, response)
-
-      {:batch_response, response, _session_id} ->
-        # Batch response
-        conn
-        |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, response)
-
-      {:no_response, _, _} ->
-        # For notifications or other messages that don't require a response
-        conn
-        |> Plug.Conn.send_resp(202, "")
-    end
+    {:ok, state}
   end
 
   @doc """
-  Process an HTTP GET request to open an SSE stream
+  List available tools for the MCP client.
+
+  This callback is invoked when the client requests the list of available tools.
   """
-  def handle_get(conn, _session_id) do
-    accept_header = Plug.Conn.get_req_header(conn, "accept")
+  @impl true
+  def handle_list_tools(state) do
+    tools = get_tools(state.opts)
 
-    if Enum.any?(accept_header, &String.contains?(&1, "text/event-stream")) do
-      # Get the current host and path to create the post URL
-      host = Plug.Conn.get_req_header(conn, "host") |> List.first()
-      scheme = if conn.scheme == :https, do: "https", else: "http"
-      path = conn.request_path
-      post_url = "#{scheme}://#{host}#{path}"
+    tool_specs =
+      Enum.map(tools, fn tool ->
+        %{
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.parameters_schema
+        }
+      end)
 
-      # Set up SSE stream
-      conn
-      |> Plug.Conn.put_resp_header("content-type", "text/event-stream")
-      |> Plug.Conn.put_resp_header("cache-control", "no-cache")
-      # Send the post_url in an endpoint event according to MCP specification
-      |> Plug.Conn.send_chunked(200)
-      |> send_sse_event("endpoint", Jason.encode!(%{"url" => post_url}))
-      |> Plug.Conn.halt()
-    else
-      # Client doesn't support SSE
-      conn
-      |> Plug.Conn.send_resp(400, "Client must accept text/event-stream")
-    end
+    {:reply, tool_specs, state}
   end
 
   @doc """
-  Handle HTTP DELETE request for session termination
-  """
-  def handle_delete(conn, session_id) do
-    if session_id do
-      conn
-      |> Plug.Conn.send_resp(200, "")
-    else
-      conn
-      |> Plug.Conn.send_resp(400, "")
-    end
-  end
+  Handle tool execution requests.
 
-  @doc """
-  Send an SSE event over the chunked connection
+  This callback is invoked when the client requests to execute a specific tool.
   """
-  def send_sse_event(conn, event, data, id \\ nil) do
-    chunks = [
-      if(id, do: "id: #{id}\n", else: ""),
-      "event: #{event}\n",
-      "data: #{data}\n\n"
-    ]
+  @impl true
+  def handle_call_tool(tool_name, arguments, state) do
+    opts = state.opts
 
-    Enum.reduce(chunks, conn, fn chunk, conn ->
-      {:ok, conn} = Plug.Conn.chunk(conn, chunk)
-      conn
-    end)
-  end
+    # Get actor, tenant, and context from opts
+    actor = opts[:actor]
+    tenant = opts[:tenant]
+    context = opts[:context] || %{}
 
-  @doc """
-  Get the MCP server version
-  """
-  def get_server_version(opts) do
-    if opts[:mcp_server_version] do
-      opts[:mcp_server_version]
-    else
-      if opts[:otp_app] do
-        case :application.get_key(opts[:otp_app], :vsn) do
-          {:ok, version} -> List.to_string(version)
-          :undefined -> "0.1.0"
+    # Find the tool
+    tools = get_tools(opts)
+
+    case Enum.find(tools, &(&1.name == tool_name)) do
+      nil ->
+        {:error, %{code: -32602, message: "Tool not found: #{tool_name}"}, state}
+
+      tool ->
+        # Build context for tool execution
+        tool_context = %{
+          actor: actor,
+          tenant: tenant,
+          context: Map.put(context, :otp_app, opts[:otp_app])
+        }
+
+        # Execute the tool
+        case tool.function.(arguments, tool_context) do
+          {:ok, result, _} ->
+            {:reply, [%{type: "text", text: result}], state}
+
+          {:error, error} ->
+            {:error,
+             %{code: -32000, message: "Tool execution failed", data: %{error: inspect(error)}},
+             state}
         end
-      else
-        "0.1.0"
-      end
     end
   end
 
   @doc """
-  Get the MCP server name
+  Get the list of tools based on options.
   """
-  def get_server_name(opts) do
-    if opts[:mcp_name] do
-      opts[:mcp_name]
-    else
-      if opts[:otp_app] do
-        "MCP Server"
-      else
-        "#{opts[:otp_app]} MCP Server"
-      end
-    end
-  end
-
-  defp process_request(request, session_id, opts) do
-    case parse_json_rpc(request) do
-      {:ok, message} when is_map(message) ->
-        # Process a single message
-        process_message(message, session_id, opts)
-
-      {:ok, batch} when is_list(batch) ->
-        # Handle batch requests
-        responses = Enum.map(batch, fn item -> process_message(item, session_id, opts) end)
-
-        # Filter out no_response items and format the response
-        response_items = Enum.filter(responses, fn {type, _, _} -> type != :no_response end)
-
-        if Enum.empty?(response_items) do
-          # All items were notifications, no response needed
-          {:no_response, nil, session_id}
-        else
-          # Convert each response to its JSON representation
-          json_responses = Enum.map(response_items, fn {_, json, _} -> json end)
-          {:batch_response, "[#{Enum.join(json_responses, ",")}]", session_id}
-        end
-
-      {:error, error} ->
-        # Handle parsing errors
-        response =
-          json_rpc_error_response(nil, -32_700, "Parse error", %{"details" => inspect(error)})
-
-        {:json_response, response, session_id}
-    end
-  end
-
-  @doc """
-  Process a single JSON-RPC message
-  """
-  def process_message(message, session_id, opts) do
-    case message do
-      %{"method" => "initialize", "id" => id, "params" => _params} ->
-        # Handle initialize request
-        new_session_id = session_id || Ash.UUIDv7.generate()
-
-        protocol_version_statement = opts[:protocol_version_statement] || "2025-03-26"
-
-        # Return capabilities
-        response = %{
-          "jsonrpc" => "2.0",
-          "id" => id,
-          "result" => %{
-            "serverInfo" => %{
-              "name" => get_server_name(opts),
-              "version" => get_server_version(opts)
-            },
-            "protocolVersion" => protocol_version_statement,
-            "capabilities" => %{
-              "tools" => %{
-                "listChanged" => false
-              }
-            }
-          }
-        }
-
-        {:initialize_response, Jason.encode!(response), new_session_id}
-
-      %{"method" => "shutdown", "id" => id, "params" => _params} ->
-        # Return success
-        response = %{
-          "jsonrpc" => "2.0",
-          "id" => id,
-          "result" => nil
-        }
-
-        {:json_response, Jason.encode!(response), session_id}
-
-      %{"method" => "$/cancelRequest", "params" => %{"id" => _request_id}} ->
-        # TODO: Cancel request?
-        {:no_response, nil, session_id}
-
-      %{"method" => "tools/list", "id" => id} ->
-        tools =
-          opts
-          |> tools()
-          |> Enum.map(fn function ->
-            %{
-              "name" => function.name,
-              "description" => function.description,
-              "inputSchema" => function.parameters_schema
-            }
-          end)
-
-        response = %{
-          "jsonrpc" => "2.0",
-          "id" => id,
-          "result" => %{
-            "tools" => tools
-          }
-        }
-
-        {:json_response, Jason.encode!(response), session_id}
-
-      %{"method" => "tools/call", "id" => id, "params" => params} ->
-        tool_name = params["name"]
-        tool_args = params["arguments"] || %{}
-
-        opts =
-          opts
-          |> Keyword.update(
-            :context,
-            %{mcp_session_id: session_id},
-            &Map.put(&1, :mcp_session_id, session_id)
-          )
-          |> Keyword.put(:filter, fn tool -> tool.mcp == :tool end)
-
-        opts
-        |> tools()
-        |> Enum.find(&(&1.name == tool_name))
-        |> case do
-          nil ->
-            response = %{
-              "jsonrpc" => "2.0",
-              "id" => id,
-              "error" => %{
-                "code" => -32_602,
-                "message" => "Tool not found: #{tool_name}"
-              }
-            }
-
-            {:json_response, Jason.encode!(response), session_id}
-
-          tool ->
-            context =
-              opts
-              |> Keyword.take([:actor, :tenant, :context])
-              |> Map.new()
-              |> Map.update(
-                :context,
-                %{otp_app: opts[:otp_app]},
-                &Map.put(&1, :otp_app, opts[:otp_app])
-              )
-
-            case tool.function.(tool_args, context) do
-              {:ok, result, _} ->
-                response = %{
-                  "jsonrpc" => "2.0",
-                  "id" => id,
-                  "result" => %{
-                    "isError" => false,
-                    "content" => [%{"type" => "text", "text" => result}]
-                  }
-                }
-
-                {:json_response, Jason.encode!(response), session_id}
-
-              {:error, error} ->
-                response = %{
-                  "jsonrpc" => "2.0",
-                  "id" => id,
-                  "error" => %{
-                    "code" => -32_000,
-                    "message" => "Tool execution failed",
-                    "data" => %{"error" => error}
-                  }
-                }
-
-                {:json_response, Jason.encode!(response), session_id}
-            end
-        end
-
-      %{"method" => method, "id" => id, "params" => _params} ->
-        # Handle other requests with IDs (requiring responses)
-        response = %{
-          "jsonrpc" => "2.0",
-          "id" => id,
-          "error" => %{
-            "code" => -32_601,
-            "message" => "Method not implemented: #{method}"
-          }
-        }
-
-        {:json_response, Jason.encode!(response), session_id}
-
-      %{"method" => _method} ->
-        # Handle other notifications (no id)
-        {:no_response, nil, session_id}
-
-      other ->
-        # Invalid message
-        {:json_response,
-         json_rpc_error_response(nil, -32_600, "Invalid Request Got: #{inspect(other)}"),
-         session_id}
-    end
-  end
-
-  defp tools(opts) do
+  defp get_tools(opts) do
     opts =
       if opts[:tools] == :ash_dev_tools do
         opts
@@ -358,34 +119,7 @@ defmodule AshAi.Mcp.Server do
       %{otp_app: opts[:otp_app]},
       &Map.put(&1, :otp_app, opts[:otp_app])
     )
+    |> Keyword.put(:filter, fn tool -> tool.mcp == :tool end)
     |> AshAi.functions()
-  end
-
-  @doc """
-  Parse the JSON-RPC request
-  """
-  def parse_json_rpc(request) when is_binary(request) do
-    case Jason.decode(request) do
-      {:ok, decoded} -> {:ok, decoded}
-      {:error, _} = error -> error
-    end
-  end
-
-  def parse_json_rpc(request) when is_map(request) do
-    {:ok, request}
-  end
-
-  @doc """
-  Create a standard JSON-RPC error response
-  """
-  def json_rpc_error_response(id, code, message, data \\ nil) do
-    error = %{"code" => code, "message" => message}
-    error = if data, do: Map.put(error, "data", data), else: error
-
-    Jason.encode!(%{
-      "jsonrpc" => "2.0",
-      "id" => id,
-      "error" => error
-    })
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -155,6 +155,7 @@ defmodule AshAi.MixProject do
       {:ash_json_api, "~> 1.4 and >= 1.4.27"},
       {:open_api_spex, "~> 3.0"},
       {:langchain, "~> 0.4"},
+      {:hermes_mcp, "~> 0.4"},
       {:ash_postgres, "~> 2.5", optional: true},
       {:ash_oban, "~> 0.5", optional: true},
       {:ash_phoenix, "~> 2.0", optional: true},


### PR DESCRIPTION
This commit replaces the custom Model Context Protocol (MCP) server implementation with the Hermes MCP SDK, a comprehensive Elixir library for MCP.

Changes:
- Add hermes_mcp dependency to mix.exs
- Rewrite AshAi.Mcp.Server to use Hermes.Server behavior
- Update AshAi.Mcp.Router to integrate with Hermes transport layer
- Simplify AshAi.Mcp.Dev to delegate to the new router
- Add Hermes.Server.Registry and DynamicSupervisor to app supervision
- Update documentation to reflect Hermes MCP usage

Benefits:
- Production-ready MCP implementation maintained by the community
- Better protocol compliance and automatic updates
- Reduced maintenance burden
- Built-in transport layer support (Streamable HTTP/SSE)

The implementation maintains backward compatibility with existing tool definitions and the Plug integration API.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
