### PR TITLE
feat: Add support for modifying the chain in prompt

### DIFF
--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -185,6 +185,8 @@ defmodule AshAi.Actions.Prompt do
 
     tools = get_tools(opts, input, context)
 
+    modify_chain = get_modify_chain(opts)
+
     messages = get_messages(input, opts, context)
 
     data = %AshAi.Actions.Prompt.Adapter.Data{
@@ -193,11 +195,22 @@ defmodule AshAi.Actions.Prompt do
       messages: messages,
       json_schema: json_schema,
       tools: tools,
+      modify_chain: modify_chain,
       verbose?: opts[:verbose?] || false,
       context: context
     }
 
     adapter.run(data, adapter_opts)
+  end
+
+  defp get_modify_chain(opts) do
+    case opts[:modify_chain] do
+      f when is_function(f, 2) ->
+        f
+
+      _ ->
+        fn chain, _context -> chain end
+    end
   end
 
   defp get_tools(opts, input, context) do

--- a/lib/ash_ai/actions/prompt/adapter.ex
+++ b/lib/ash_ai/actions/prompt/adapter.ex
@@ -43,6 +43,7 @@ defmodule AshAi.Actions.Prompt.Adapter do
       :verbose?,
       :json_schema,
       :tools,
+      :modify_chain,
       :context
     ]
 
@@ -52,6 +53,9 @@ defmodule AshAi.Actions.Prompt.Adapter do
             messages: list(),
             json_schema: map(),
             tools: list(),
+            modify_chain: (LangChain.Chains.LLMChain.t(),
+                           Ash.Resource.Actions.Implementation.Context.t() ->
+                             LangChain.Chains.LLMChain.t()),
             verbose?: boolean(),
             context: Ash.Resource.Actions.Implementation.Context.t()
           }

--- a/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
+++ b/lib/ash_ai/actions/prompt/adapter/completion_tool.ex
@@ -86,6 +86,7 @@ defmodule AshAi.Actions.Prompt.Adapter.CompletionTool do
     |> LLMChain.new!()
     |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools([completion_tool | data.tools])
+    |> data.modify_chain.(data.context)
     |> LLMChain.run_until_tool_used("complete_request", max_runs: max_runs)
     |> case do
       {:ok, _chain, message} ->

--- a/lib/ash_ai/actions/prompt/adapter/raw.ex
+++ b/lib/ash_ai/actions/prompt/adapter/raw.ex
@@ -26,6 +26,7 @@ defmodule AshAi.Actions.Prompt.Adapter.Raw do
     |> LLMChain.new!()
     |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(data.messages, data)
     |> LLMChain.add_tools(data.tools)
+    |> data.modify_chain.(data.context)
     |> LLMChain.run(mode: :while_needs_response)
     |> case do
       {:ok, %LLMChain{last_message: %{content: content}}}

--- a/lib/ash_ai/actions/prompt/adapter/request_json.ex
+++ b/lib/ash_ai/actions/prompt/adapter/request_json.ex
@@ -58,6 +58,7 @@ defmodule AshAi.Actions.Prompt.Adapter.RequestJson do
     |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools(data.tools)
     |> LLMChain.message_processors([json_processor])
+    |> data.modify_chain.(data.context)
     |> run_with_retries(data, max_retries, 0)
   end
 

--- a/lib/ash_ai/actions/prompt/adapter/structured_output.ex
+++ b/lib/ash_ai/actions/prompt/adapter/structured_output.ex
@@ -44,6 +44,7 @@ defmodule AshAi.Actions.Prompt.Adapter.StructuredOutput do
     |> LLMChain.new!()
     |> AshAi.Actions.Prompt.Adapter.Helpers.add_messages_with_templates(messages, data)
     |> LLMChain.add_tools(data.tools)
+    |> data.modify_chain.(data.context)
     |> LLMChain.run(mode: :while_needs_response)
     |> case do
       {:ok, %LLMChain{last_message: %{content: content}}}


### PR DESCRIPTION
This PR adds support for a `modify_chain` argument to the `prompt` function used in prompt-driven actions. This allows users to manually change the chain at will, e.g. to add native tools, such as Google's search grounding.

Fixes: #101

I wasn't sure how best to test this feature. Any help would be greatly appreciated, so I can add some proper unit/acceptance tests.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
