### PR TITLE
Fix issue with AshOban compiling before AshAi action definition

### DIFF
--- a/lib/ash_ai/transformers/vectorize.ex
+++ b/lib/ash_ai/transformers/vectorize.ex
@@ -9,7 +9,11 @@ defmodule AshAi.Transformers.Vectorize do
   import Spark.Dsl.Builder
   import Ash.Resource.Builder
 
+  def after?(AshOban.Transformers.SetDefaults), do: false
   def after?(_), do: true
+
+  def before?(AshOban.Transformers.SetDefaults), do: true
+  def before?(_), do: false
 
   def transform(dsl) do
     attrs =


### PR DESCRIPTION
Fix for [143](https://github.com/ash-project/ash_ai/issues/143)

This fixes a compilation issue where AshOban would try to compile before ash_ai adds its `ash_ai_update_embeddings` action to the resource.

I tried all different permutations of before/ after clauses. For whatever reason, no single before or after statement work - but both together do.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
