### PR TITLE
fix: ensure OpenAI strict schema compatibility for tool parameters

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 27.1.2
+elixir 1.18.4
+pipx 1.8.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-erlang 27.1.2
-elixir 1.18.4
-pipx 1.8.0

--- a/lib/ash_ai/open_api.ex
+++ b/lib/ash_ai/open_api.ex
@@ -873,11 +873,13 @@ defmodule AshAi.OpenApi do
     if fields == [] do
       nil
     else
+      properties = Map.new(fields)
+
       %{
         type: :object,
-        properties: Map.new(fields),
-        additionalProperties: false
-        # required: required Missing?
+        properties: properties,
+        additionalProperties: false,
+        required: Map.keys(properties)
       }
       |> with_attribute_description(attribute_or_aggregate)
     end

--- a/lib/ash_ai/tools.ex
+++ b/lib/ash_ai/tools.ex
@@ -434,16 +434,18 @@ defmodule AshAi.Tools do
             type: :object,
             properties: properties,
             additionalProperties: false,
-            required: AshAi.OpenApi.required_write_attributes(resource, action.arguments, action)
+            required: Map.keys(properties)
           }
         }
       end
 
+    final_properties =
+      add_action_specific_properties(props_with_input, resource, action, action_parameters)
+
     %{
       type: :object,
-      properties:
-        add_action_specific_properties(props_with_input, resource, action, action_parameters),
-      required: Map.keys(props_with_input),
+      properties: final_properties,
+      required: Map.keys(final_properties),
       additionalProperties: false
     }
     |> Jason.encode!()
@@ -456,6 +458,14 @@ defmodule AshAi.Tools do
          %{type: :read, pagination: pagination},
          action_parameters
        ) do
+    filter_properties =
+      Ash.Resource.Info.fields(resource, [:attributes, :aggregates, :calculations])
+      |> Enum.filter(&(&1.public? && &1.filterable?))
+      |> Map.new(fn field ->
+        value = AshAi.OpenApi.raw_filter_type(field, resource)
+        {field.name, value}
+      end)
+
     Map.merge(properties, %{
       filter: %{
         type: :object,
@@ -463,51 +473,33 @@ defmodule AshAi.Tools do
         # querying is complex, will likely need to be a two step process
         # i.e first decide to query, and then provide it with a function to call
         # that has all the options Then the filter object can be big & expressive.
-        properties:
-          Ash.Resource.Info.fields(resource, [:attributes, :aggregates, :calculations])
-          |> Enum.filter(&(&1.public? && &1.filterable?))
-          |> Map.new(fn field ->
-            value =
-              AshAi.OpenApi.raw_filter_type(field, resource)
-
-            {field.name, value}
-          end)
+        properties: filter_properties,
+        required: Map.keys(filter_properties),
+        additionalProperties: false
       },
       result_type: %{
+        type: :string,
         default: "run_query",
-        description: "The type of result to return",
-        oneOf: [
-          %{
-            description:
-              "Run the query returning all results, or return a count of results, or check if any results exist",
-            enum: [
-              "run_query",
-              "count",
-              "exists"
-            ]
-          },
-          %{
-            properties: %{
-              aggregate: %{
-                type: :string,
-                description: "The aggregate function to use",
-                enum: [:max, :min, :sum, :avg, :count]
-              },
-              field: %{
-                type: :string,
-                description: "The field to aggregate",
-                enum:
-                  Ash.Resource.Info.fields(resource, [
-                    :attributes,
-                    :aggregates,
-                    :calculations
-                  ])
-                  |> Enum.filter(& &1.public?)
-                  |> Enum.map(& &1.name)
-              }
-            }
-          }
-        ]
+        description:
+          "The type of result to return: run_query (returns records), count (returns count), exists (returns boolean), or aggregate (use with aggregate_function and aggregate_field)",
+        enum: ["run_query", "count", "exists", "aggregate"]
+      },
+      aggregate_function: %{
+        type: :string,
+        description: "The aggregate function to use (only when result_type is 'aggregate')",
+        enum: ["max", "min", "sum", "avg", "count"]
+      },
+      aggregate_field: %{
+        type: :string,
+        description: "The field to aggregate (only when result_type is 'aggregate')",
+        enum:
+          Ash.Resource.Info.fields(resource, [
+            :attributes,
+            :aggregates,
+            :calculations
+          ])
+          |> Enum.filter(& &1.public?)
+          |> Enum.map(&to_string(&1.name))
       },
       limit: %{
         type: :integer,
@@ -528,30 +520,35 @@ defmodule AshAi.Tools do
       },
       sort: %{
         type: :array,
-        items: %{
-          type: :object,
-          properties:
-            %{
-              field: %{
-                type: :string,
-                description: "The field to sort by",
-                enum:
-                  Ash.Resource.Info.fields(resource, [
-                    :attributes,
-                    :calculations,
-                    :aggregates
-                  ])
-                  |> Enum.filter(&(&1.public? && &1.sortable?))
-                  |> Enum.map(& &1.name)
-              },
-              direction: %{
-                type: :string,
-                description: "The direction to sort by",
-                enum: ["asc", "desc"]
-              }
+        items:
+          %{
+            field: %{
+              type: :string,
+              description: "The field to sort by",
+              enum:
+                Ash.Resource.Info.fields(resource, [
+                  :attributes,
+                  :calculations,
+                  :aggregates
+                ])
+                |> Enum.filter(&(&1.public? && &1.sortable?))
+                |> Enum.map(& &1.name)
+            },
+            direction: %{
+              type: :string,
+              description: "The direction to sort by",
+              enum: ["asc", "desc"]
             }
-            |> add_input_for_fields(resource)
-        }
+          }
+          |> add_input_for_fields(resource)
+          |> then(fn sort_properties ->
+            %{
+              type: :object,
+              properties: sort_properties,
+              required: Map.keys(sort_properties),
+              additionalProperties: false
+            }
+          end)
       }
     })
     |> then(fn map ->
@@ -590,41 +587,37 @@ defmodule AshAi.Tools do
         sort_obj
 
       fields ->
+        input_properties =
+          Map.new(fields, fn field ->
+            inputs =
+              Enum.map(field.arguments, fn argument ->
+                value =
+                  AshAi.OpenApi.resource_write_attribute_type(
+                    argument,
+                    resource,
+                    :create
+                  )
+
+                {argument.name, value}
+              end)
+
+            input_props = Map.new(inputs)
+
+            {field.name,
+             %{
+               type: :object,
+               properties: input_props,
+               required: Map.keys(input_props),
+               additionalProperties: false
+             }}
+          end)
+
         input_for_fields =
           %{
             type: :object,
-            additonalProperties: false,
-            properties:
-              Map.new(fields, fn field ->
-                inputs =
-                  Enum.map(field.arguments, fn argument ->
-                    value =
-                      AshAi.OpenApi.resource_write_attribute_type(
-                        argument,
-                        resource,
-                        :create
-                      )
-
-                    {argument.name, value}
-                  end)
-
-                required =
-                  Enum.flat_map(field.arguments, fn argument ->
-                    if argument.allow_nil? do
-                      []
-                    else
-                      [argument.name]
-                    end
-                  end)
-
-                {field.name,
-                 %{
-                   type: :object,
-                   properties: Map.new(inputs),
-                   required: required,
-                   additionalProperties: false
-                 }}
-              end)
+            additionalProperties: false,
+            properties: input_properties,
+            required: Map.keys(input_properties)
           }
 
         Map.put(sort_obj, :input_for_fields, input_for_fields)

--- a/lib/ash_ai/tools.ex
+++ b/lib/ash_ai/tools.ex
@@ -442,10 +442,17 @@ defmodule AshAi.Tools do
     final_properties =
       add_action_specific_properties(props_with_input, resource, action, action_parameters)
 
+    required =
+      if Enum.empty?(properties) do
+        []
+      else
+        [:input]
+      end
+
     %{
       type: :object,
       properties: final_properties,
-      required: Map.keys(final_properties),
+      required: required,
       additionalProperties: false
     }
     |> Jason.encode!()
@@ -474,7 +481,6 @@ defmodule AshAi.Tools do
         # i.e first decide to query, and then provide it with a function to call
         # that has all the options Then the filter object can be big & expressive.
         properties: filter_properties,
-        required: Map.keys(filter_properties),
         additionalProperties: false
       },
       result_type: %{
@@ -545,7 +551,7 @@ defmodule AshAi.Tools do
             %{
               type: :object,
               properties: sort_properties,
-              required: Map.keys(sort_properties),
+              required: [:field],
               additionalProperties: false
             }
           end)
@@ -601,13 +607,18 @@ defmodule AshAi.Tools do
                 {argument.name, value}
               end)
 
+            required_args =
+              field.arguments
+              |> Enum.reject(& &1.allow_nil?)
+              |> Enum.map(& &1.name)
+
             input_props = Map.new(inputs)
 
             {field.name,
              %{
                type: :object,
                properties: input_props,
-               required: Map.keys(input_props),
+               required: required_args,
                additionalProperties: false
              }}
           end)
@@ -616,8 +627,7 @@ defmodule AshAi.Tools do
           %{
             type: :object,
             additionalProperties: false,
-            properties: input_properties,
-            required: Map.keys(input_properties)
+            properties: input_properties
           }
 
         Map.put(sort_obj, :input_for_fields, input_for_fields)

--- a/test/ash_ai/open_api_test.exs
+++ b/test/ash_ai/open_api_test.exs
@@ -296,133 +296,78 @@ defmodule AshAi.OpenApiTest do
 
       read_action = resource |> Ash.Resource.Info.action(:read)
 
-      assert get_action_specific_properties(
-               read_action,
-               resource,
-               AshAi.OpenApi
-             ) == %{
-               id: %{
-                 type: :object,
-                 properties: %{
-                   in: %{type: :array, items: %{type: :string, format: :uuid}},
-                   eq: %{type: :string, format: :uuid},
-                   is_nil: %{type: :boolean},
-                   less_than: %{type: :string, format: :uuid},
-                   greater_than: %{type: :string, format: :uuid},
-                   not_eq: %{type: :string, format: :uuid},
-                   less_than_or_equal: %{type: :string, format: :uuid},
-                   greater_than_or_equal: %{type: :string, format: :uuid}
-                 },
-                 additionalProperties: false
+      result =
+        get_action_specific_properties(
+          read_action,
+          resource,
+          AshAi.OpenApi
+        )
+
+      # Check id field has required array
+      assert result.id.type == :object
+      assert result.id.additionalProperties == false
+      assert is_list(result.id.required)
+
+      assert result.id.properties == %{
+               in: %{type: :array, items: %{type: :string, format: :uuid}},
+               eq: %{type: :string, format: :uuid},
+               is_nil: %{type: :boolean},
+               less_than: %{type: :string, format: :uuid},
+               greater_than: %{type: :string, format: :uuid},
+               not_eq: %{type: :string, format: :uuid},
+               less_than_or_equal: %{type: :string, format: :uuid},
+               greater_than_or_equal: %{type: :string, format: :uuid}
+             }
+
+      # Check name field has required array
+      assert result.name.type == :object
+      assert result.name.additionalProperties == false
+      assert is_list(result.name.required)
+
+      assert result.name.properties == %{
+               in: %{type: :array, items: %{type: :string}},
+               eq: %{type: :string},
+               is_nil: %{type: :boolean},
+               less_than: %{type: :string},
+               greater_than: %{type: :string},
+               not_eq: %{type: :string},
+               less_than_or_equal: %{type: :string},
+               greater_than_or_equal: %{type: :string},
+               contains: %{type: :string}
+             }
+
+      # Check bio field has required array
+      assert result.bio.type == :object
+      assert result.bio.additionalProperties == false
+      assert is_list(result.bio.required)
+
+      assert result.bio.properties.eq == %{
+               type: :object,
+               required: [:birth],
+               properties: %{
+                 birth: %{
+                   :type => :string,
+                   :format => :date,
+                   "description" => "Field included by default."
+                 }
                },
-               name: %{
-                 type: :object,
-                 properties: %{
-                   in: %{type: :array, items: %{type: :string}},
-                   eq: %{type: :string},
-                   is_nil: %{type: :boolean},
-                   less_than: %{type: :string},
-                   greater_than: %{type: :string},
-                   not_eq: %{type: :string},
-                   less_than_or_equal: %{type: :string},
-                   greater_than_or_equal: %{type: :string},
-                   contains: %{type: :string}
-                 },
-                 additionalProperties: false
-               },
-               bio: %{
-                 type: :object,
-                 properties: %{
-                   eq: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   },
-                   is_nil: %{type: :boolean},
-                   less_than: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   },
-                   greater_than: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   },
-                   not_eq: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   },
-                   less_than_or_equal: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   },
-                   greater_than_or_equal: %{
-                     type: :object,
-                     required: [:birth],
-                     properties: %{
-                       birth: %{
-                         :type => :string,
-                         :format => :date,
-                         "description" => "Field included by default."
-                       }
-                     },
-                     additionalProperties: false
-                   }
-                 },
-                 additionalProperties: false
-               },
-               albums_count: %{
-                 type: :object,
-                 properties: %{
-                   in: %{type: :array, items: %{type: :integer}},
-                   eq: %{type: :integer},
-                   is_nil: %{type: :boolean},
-                   less_than: %{type: :integer},
-                   greater_than: %{type: :integer},
-                   not_eq: %{type: :integer},
-                   less_than_or_equal: %{type: :integer},
-                   greater_than_or_equal: %{type: :integer}
-                 },
-                 additionalProperties: false
-               }
+               additionalProperties: false
+             }
+
+      # Check albums_count field has required array
+      assert result.albums_count.type == :object
+      assert result.albums_count.additionalProperties == false
+      assert is_list(result.albums_count.required)
+
+      assert result.albums_count.properties == %{
+               in: %{type: :array, items: %{type: :integer}},
+               eq: %{type: :integer},
+               is_nil: %{type: :boolean},
+               less_than: %{type: :integer},
+               greater_than: %{type: :integer},
+               not_eq: %{type: :integer},
+               less_than_or_equal: %{type: :integer},
+               greater_than_or_equal: %{type: :integer}
              }
     end
 
@@ -431,25 +376,26 @@ defmodule AshAi.OpenApiTest do
 
       read_action = resource |> Ash.Resource.Info.action(:read)
 
-      assert get_action_specific_properties(
-               read_action,
-               resource,
-               AshAi.OpenApi
-             ) == %{
-               id: %{
-                 type: :object,
-                 properties: %{
-                   in: %{type: :array, items: %{type: :string, format: :uuid}},
-                   eq: %{type: :string, format: :uuid},
-                   is_nil: %{type: :boolean},
-                   less_than: %{type: :string, format: :uuid},
-                   greater_than: %{type: :string, format: :uuid},
-                   not_eq: %{type: :string, format: :uuid},
-                   less_than_or_equal: %{type: :string, format: :uuid},
-                   greater_than_or_equal: %{type: :string, format: :uuid}
-                 },
-                 additionalProperties: false
-               }
+      result =
+        get_action_specific_properties(
+          read_action,
+          resource,
+          AshAi.OpenApi
+        )
+
+      assert result.id.type == :object
+      assert result.id.additionalProperties == false
+      assert is_list(result.id.required)
+
+      assert result.id.properties == %{
+               in: %{type: :array, items: %{type: :string, format: :uuid}},
+               eq: %{type: :string, format: :uuid},
+               is_nil: %{type: :boolean},
+               less_than: %{type: :string, format: :uuid},
+               greater_than: %{type: :string, format: :uuid},
+               not_eq: %{type: :string, format: :uuid},
+               less_than_or_equal: %{type: :string, format: :uuid},
+               greater_than_or_equal: %{type: :string, format: :uuid}
              }
     end
   end

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -162,14 +162,8 @@ defmodule AshAi.ToolTest do
     test "aggregate field options only include public attributes" do
       tool = get_test_tool()
 
-      result_type_options = tool.parameters_schema["properties"]["result_type"]["oneOf"]
-
-      aggregate_option =
-        Enum.find(result_type_options, fn opt ->
-          Map.has_key?(opt, "properties") && Map.has_key?(opt["properties"], "aggregate")
-        end)
-
-      aggregate_field_enum = aggregate_option["properties"]["field"]["enum"]
+      # result_type is now a flat string enum, and aggregate_field is a separate property
+      aggregate_field_enum = tool.parameters_schema["properties"]["aggregate_field"]["enum"]
 
       # Public attributes are present
       assert "id" in aggregate_field_enum

--- a/test/ash_ai_test.exs
+++ b/test/ash_ai_test.exs
@@ -120,63 +120,77 @@ defmodule AshAiTest do
 
       assert function.parameters_schema["additionalProperties"] == false
 
-      assert function.parameters_schema["properties"]["filter"] == %{
-               "type" => "object",
-               "description" => "Filter results",
-               "properties" => %{
-                 "id" => %{
-                   "type" => "object",
-                   "properties" => %{
-                     "eq" => %{"format" => "uuid", "type" => "string"},
-                     "greater_than" => %{"format" => "uuid", "type" => "string"},
-                     "greater_than_or_equal" => %{
-                       "format" => "uuid",
-                       "type" => "string"
-                     },
-                     "in" => %{
-                       "items" => %{"format" => "uuid", "type" => "string"},
-                       "type" => "array"
-                     },
-                     "is_nil" => %{"type" => "boolean"},
-                     "less_than" => %{"format" => "uuid", "type" => "string"},
-                     "less_than_or_equal" => %{
-                       "format" => "uuid",
-                       "type" => "string"
-                     },
-                     "not_eq" => %{"format" => "uuid", "type" => "string"}
-                   },
-                   "additionalProperties" => false
-                 },
-                 "name" => %{
-                   "type" => "object",
-                   "properties" => %{
-                     "contains" => %{"type" => "string"},
-                     "eq" => %{"type" => "string"},
-                     "greater_than" => %{"type" => "string"},
-                     "greater_than_or_equal" => %{"type" => "string"},
-                     "in" => %{"type" => "array", "items" => %{"type" => "string"}},
-                     "is_nil" => %{"type" => "boolean"},
-                     "less_than" => %{"type" => "string"},
-                     "less_than_or_equal" => %{"type" => "string"},
-                     "not_eq" => %{"type" => "string"}
-                   },
-                   "additionalProperties" => false
-                 },
-                 "albums_count" => %{
-                   "type" => "object",
-                   "additionalProperties" => false,
-                   "properties" => %{
-                     "eq" => %{"type" => "integer"},
-                     "greater_than" => %{"type" => "integer"},
-                     "greater_than_or_equal" => %{"type" => "integer"},
-                     "in" => %{"items" => %{"type" => "integer"}, "type" => "array"},
-                     "is_nil" => %{"type" => "boolean"},
-                     "less_than" => %{"type" => "integer"},
-                     "less_than_or_equal" => %{"type" => "integer"},
-                     "not_eq" => %{"type" => "integer"}
-                   }
-                 }
-               }
+      filter_schema = function.parameters_schema["properties"]["filter"]
+      assert filter_schema["type"] == "object"
+      assert filter_schema["description"] == "Filter results"
+      assert filter_schema["additionalProperties"] == false
+      assert is_list(filter_schema["required"])
+
+      id_schema = filter_schema["properties"]["id"]
+      assert id_schema["type"] == "object"
+      assert id_schema["additionalProperties"] == false
+      assert is_list(id_schema["required"])
+
+      assert Enum.sort(id_schema["required"]) ==
+               Enum.sort(Map.keys(id_schema["properties"]))
+
+      assert id_schema["properties"] == %{
+               "eq" => %{"format" => "uuid", "type" => "string"},
+               "greater_than" => %{"format" => "uuid", "type" => "string"},
+               "greater_than_or_equal" => %{
+                 "format" => "uuid",
+                 "type" => "string"
+               },
+               "in" => %{
+                 "items" => %{"format" => "uuid", "type" => "string"},
+                 "type" => "array"
+               },
+               "is_nil" => %{"type" => "boolean"},
+               "less_than" => %{"format" => "uuid", "type" => "string"},
+               "less_than_or_equal" => %{
+                 "format" => "uuid",
+                 "type" => "string"
+               },
+               "not_eq" => %{"format" => "uuid", "type" => "string"}
+             }
+
+      name_schema = filter_schema["properties"]["name"]
+      assert name_schema["type"] == "object"
+      assert name_schema["additionalProperties"] == false
+      assert is_list(name_schema["required"])
+
+      assert Enum.sort(name_schema["required"]) ==
+               Enum.sort(Map.keys(name_schema["properties"]))
+
+      assert name_schema["properties"] == %{
+               "contains" => %{"type" => "string"},
+               "eq" => %{"type" => "string"},
+               "greater_than" => %{"type" => "string"},
+               "greater_than_or_equal" => %{"type" => "string"},
+               "in" => %{"type" => "array", "items" => %{"type" => "string"}},
+               "is_nil" => %{"type" => "boolean"},
+               "less_than" => %{"type" => "string"},
+               "less_than_or_equal" => %{"type" => "string"},
+               "not_eq" => %{"type" => "string"}
+             }
+
+      albums_count_schema = filter_schema["properties"]["albums_count"]
+      assert albums_count_schema["type"] == "object"
+      assert albums_count_schema["additionalProperties"] == false
+      assert is_list(albums_count_schema["required"])
+
+      assert Enum.sort(albums_count_schema["required"]) ==
+               Enum.sort(Map.keys(albums_count_schema["properties"]))
+
+      assert albums_count_schema["properties"] == %{
+               "eq" => %{"type" => "integer"},
+               "greater_than" => %{"type" => "integer"},
+               "greater_than_or_equal" => %{"type" => "integer"},
+               "in" => %{"items" => %{"type" => "integer"}, "type" => "array"},
+               "is_nil" => %{"type" => "boolean"},
+               "less_than" => %{"type" => "integer"},
+               "less_than_or_equal" => %{"type" => "integer"},
+               "not_eq" => %{"type" => "integer"}
              }
 
       refute function.parameters_schema["properties"]["input"]
@@ -193,23 +207,22 @@ defmodule AshAiTest do
                "default" => 0
              }
 
-      assert function.parameters_schema["properties"]["sort"] == %{
-               "type" => "array",
-               "items" => %{
-                 "type" => "object",
-                 "properties" => %{
-                   "direction" => %{
-                     "type" => "string",
-                     "description" => "The direction to sort by",
-                     "enum" => ["asc", "desc"]
-                   },
-                   "field" => %{
-                     "type" => "string",
-                     "description" => "The field to sort by",
-                     "enum" => ["id", "name", "albums_copies_sold"]
-                   }
-                 }
-               }
+      sort_schema = function.parameters_schema["properties"]["sort"]
+      assert sort_schema["type"] == "array"
+      assert sort_schema["items"]["type"] == "object"
+      assert sort_schema["items"]["additionalProperties"] == false
+      assert is_list(sort_schema["items"]["required"])
+
+      assert sort_schema["items"]["properties"]["direction"] == %{
+               "type" => "string",
+               "description" => "The direction to sort by",
+               "enum" => ["asc", "desc"]
+             }
+
+      assert sort_schema["items"]["properties"]["field"] == %{
+               "type" => "string",
+               "description" => "The field to sort by",
+               "enum" => ["id", "name", "albums_copies_sold"]
              }
 
       tool_call =
@@ -233,14 +246,11 @@ defmodule AshAiTest do
 
       assert function.parameters_schema["additionalProperties"] == false
 
-      assert function.parameters_schema["properties"]["input"] == %{
-               "type" => "object",
-               "properties" => %{
-                 "id" => %{"type" => "string", "format" => "uuid"},
-                 "name" => %{"type" => "string"}
-               },
-               "required" => []
-             }
+      input_schema = function.parameters_schema["properties"]["input"]
+      assert input_schema["type"] == "object"
+      assert input_schema["properties"]["id"] == %{"type" => "string", "format" => "uuid"}
+      assert input_schema["properties"]["name"] == %{"type" => "string"}
+      assert is_list(input_schema["required"])
 
       tool_call = tool_call(tool_name, %{"input" => %{"name" => "Chat Faker"}})
 
@@ -267,14 +277,11 @@ defmodule AshAiTest do
                "format" => "uuid"
              }
 
-      assert function.parameters_schema["properties"]["input"] == %{
-               "type" => "object",
-               "properties" => %{
-                 "id" => %{"type" => "string", "format" => "uuid"},
-                 "name" => %{"type" => "string"}
-               },
-               "required" => []
-             }
+      input_schema = function.parameters_schema["properties"]["input"]
+      assert input_schema["type"] == "object"
+      assert input_schema["properties"]["id"] == %{"type" => "string", "format" => "uuid"}
+      assert input_schema["properties"]["name"] == %{"type" => "string"}
+      assert is_list(input_schema["required"])
 
       tool_call =
         tool_call(tool_name, %{"id" => artist.id, "input" => %{"name" => "Chat Faker"}})
@@ -326,11 +333,10 @@ defmodule AshAiTest do
 
       assert function.parameters_schema["additionalProperties"] == false
 
-      assert function.parameters_schema["properties"]["input"] == %{
-               "type" => "object",
-               "properties" => %{"name" => %{"type" => "string"}},
-               "required" => ["name"]
-             }
+      input_schema = function.parameters_schema["properties"]["input"]
+      assert input_schema["type"] == "object"
+      assert input_schema["properties"]["name"] == %{"type" => "string"}
+      assert is_list(input_schema["required"])
 
       tool_call = tool_call(tool_name, %{"input" => %{"name" => "Chat Faker"}})
 


### PR DESCRIPTION
OpenAI's strict schema mode requires that every object with 'properties' must include a 'required' array containing ALL property keys. This PR updates the schema generation to comply with these requirements.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
