### PR TITLE
tools maintain prepared loads on serialization

### DIFF
--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -64,6 +64,29 @@ defmodule AshAi.Serializer do
         key -> key
       end)
 
+    prepared_fields =
+      [
+        resource
+        |> Ash.Resource.Info.calculations()
+        |> Enum.filter(fn calculation ->
+          !match?(%Ash.NotLoaded{}, Map.get(record, calculation.name))
+        end)
+        |> Enum.map(& &1.name),
+        resource
+        |> Ash.Resource.Info.aggregates()
+        |> Enum.filter(fn aggregate ->
+          !match?(%Ash.NotLoaded{}, Map.get(record, aggregate.name))
+        end)
+        |> Enum.map(& &1.name),
+        resource
+        |> Ash.Resource.Info.relationships()
+        |> Enum.filter(fn relationship ->
+          !match?(%Ash.NotLoaded{}, Map.get(record, relationship.name))
+        end)
+        |> Enum.map(& &1.name)
+      ]
+      |> List.flatten()
+
     fields =
       if opts[:top_level?] do
         Map.get(request.fields, resource) || Map.get(request.route, :default_fields) ||
@@ -73,6 +96,8 @@ defmodule AshAi.Serializer do
           default_attributes(resource)
       end
       |> Enum.concat(load_fields)
+      |> Enum.concat(prepared_fields)
+      |> Enum.uniq()
 
     Enum.reduce(fields, %{}, fn field_name, acc ->
       field = Ash.Resource.Info.field(resource, field_name)


### PR DESCRIPTION
Hey All,

For context I have an app that has a calculation which takes in an optional argument and wanted to use a read tool definition to load that calculation through MCP.

I ran into issues where the loaded calculation would always return the default value rather than what the read action prepared.

After some digging I believe that the serializer was not considering prepared loads and these changes are what made it work for me. All of the tests ran the same before and after these changes.

I'm certain there is better way to address this in a larger refactor, but I didn't want to touch too much while trying to present this.

There is also a chance that I am just ignorant to a more streamlined solution of passing arguments to the calculation load in the tool definition, and if that is the case please educate me.

Best,
Josh

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
