### PR TITLE
feat: Add ChatOpenAiResponses support

### DIFF
--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -289,7 +289,12 @@ defmodule AshAi.Actions.Prompt do
             # For non-OpenAI endpoints, use RequestJson
             AshAi.Actions.Prompt.Adapter.RequestJson
 
-          %LangChain.ChatModels.ChatOpenAIResponses{} ->
+          %LangChain.ChatModels.ChatOpenAIResponses{endpoint: "https://api.openai.com" <> _rest} ->
+            AshAi.Actions.Prompt.Adapter.StructuredOutput
+
+          %LangChain.ChatModels.ChatOpenAIResponses{endpoint: endpoint}
+          when not is_nil(endpoint) ->
+            # For non-OpenAI endpoints, use RequestJson
             AshAi.Actions.Prompt.Adapter.RequestJson
 
           %LangChain.ChatModels.ChatAnthropic{} ->


### PR DESCRIPTION
This PR adds support to use ChatOpenAiResponses with AshAi.

I looked into the tests but it doesn't seem like there is a test right now testing this path, so I didn't add any.

Regardless, I testes the code with the real API and it works great.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
