### PR TITLE
fix: skip NotLoaded attributes in serializer

### DIFF
--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -147,6 +147,10 @@ defmodule AshAi.Serializer do
             match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
           acc
 
+        match?(%Ash.Resource.Attribute{}, field) &&
+            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
+          acc
+
         true ->
           new_load =
             load


### PR DESCRIPTION
Fixes #165

The serializer skips `%Ash.NotLoaded{}` for relationships, calculations, and aggregates, but not for attributes. This causes crashes when using `prepare build(select: [...])` to optimize action responses.

Adds the same pattern for attributes (4 lines), matching `ash_json_api` behavior.

---

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md). AI was used to help draft this PR.