### PR TITLE
fix: Makes sure OpenApi schema required list is sorted

### DIFF
--- a/lib/ash_ai/open_api.ex
+++ b/lib/ash_ai/open_api.ex
@@ -373,7 +373,9 @@ defmodule AshAi.OpenApi do
   # this is kind of a hack, specifically because open ai requires that all fields
   # be required. But the value can be `null`
   defp make_all_required(map) do
-    Map.put(map, :required, Map.keys(map.properties))
+    required_list = map.properties |> Map.keys() |> Enum.sort()
+
+    Map.put(map, :required, required_list)
   end
 
   @doc false


### PR DESCRIPTION
This is a very simple PR that basically guarantees that an OpenApi schema is always generated the exact same way if the inputs are the same.

Basically, the required list in the schema is not deterministic, since `Map.keys()` doesn't guarantee the order the data will output. This means that, if you call that function with the same input multiple times, there is no guarantee that it will output the list in the exact same order.

In my specific use case, this is a big issue because I have a cache system where one of the things I use as the key to the cache, is this schema. and since any required list inside the schema doesn't guarantee order, I was having a bunch of cache misses because of that.

This PR fixes that by sorting the list.

Since it is such a minor change, I didn't change any unit tests, I hope that is OK, but I can create some if needed.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
