### PR TITLE
Fix update tool identity lookup for nested input

### DIFF
--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -346,7 +346,7 @@ defmodule AshAi.Tool.Execution do
     resource
     |> Ash.Resource.Info.primary_key()
     |> Enum.reduce(nil, fn key, expr ->
-      value = Map.get(arguments, to_string(key))
+      value = argument_value(arguments, key)
 
       if expr do
         Ash.Expr.expr(^expr and ^Ash.Expr.ref(key) == ^value)
@@ -362,8 +362,23 @@ defmodule AshAi.Tool.Execution do
     |> Enum.find(&(&1.name == identity))
     |> Map.get(:keys)
     |> Enum.map(fn key ->
-      {key, Map.get(arguments, to_string(key))}
+      {key, argument_value(arguments, key)}
     end)
+  end
+
+  defp argument_value(arguments, key) do
+    key = to_string(key)
+
+    cond do
+      is_map(arguments["input"]) && Map.has_key?(arguments["input"], key) ->
+        arguments["input"][key]
+
+      Map.has_key?(arguments, key) ->
+        arguments[key]
+
+      true ->
+        nil
+    end
   end
 
   defp validate_inputs!(resource, client_input, action, tool_arguments) do

--- a/test/ash_ai_test.exs
+++ b/test/ash_ai_test.exs
@@ -160,6 +160,16 @@ defmodule AshAiTest do
       assert updated_raw.name == "Updated"
       assert is_binary(updated_json)
 
+      {:ok, nested_updated_json, nested_updated_raw} =
+        registry["update_artist"].(
+          %{"input" => %{"id" => artist.id, "name" => "Nested Updated"}},
+          context
+        )
+
+      assert nested_updated_raw.id == artist.id
+      assert nested_updated_raw.name == "Nested Updated"
+      assert is_binary(nested_updated_json)
+
       {:ok, read_json, read_raw} =
         registry["list_artists"].(%{"filter" => %{"id" => %{"eq" => artist.id}}}, context)
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Fixes update tool identity lookup when callers pass the record identity inside the nested `input` payload generated by tool schemas.

Previously, update/destroy identity filters only read identity values from top-level arguments. A call like:

```elixir
%{"input" => %{"id" => id, "name" => "Nested Updated"}}
```

built an update filter like `id == nil`, causing the update tool to fail even though the schema places action inputs under `input`.

## Changes

- Look up identity values in `arguments["input"]` first, falling back to top-level arguments for compatibility.
- Add a regression assertion for nested-input update tool calls.

## Verification

Passed:

```bash
mix test test/ash_ai_test.exs --max-failures 1
```

I also attempted `mix test.create && mix test.migrate && mix check`, but local migration failed because my PostgreSQL installation does not have the `vector` extension installed:

```text
ERROR 0A000 (feature_not_supported) extension "vector" is not available
Could not open extension control file .../vector.control
```
