### PR TITLE
fix: serialize Union values before JSON encoding in Tools.execute

### DIFF
--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -17,6 +17,30 @@ defmodule AshAi.Serializer do
     Decimal.to_string(value)
   end
 
+  def serialize_value(%Ash.Union{type: union_type, value: inner}, type, constraints, domain, opts) do
+    {type, constraints} = flatten_new_type(type, constraints || [])
+
+    type_config =
+      if type == Ash.Type.Union do
+        Keyword.get(constraints[:types] || [], union_type)
+      end
+
+    if type_config do
+      inner_type = type_config[:type]
+      inner_constraints = type_config[:constraints] || []
+
+      serialized = serialize_value(inner, inner_type, inner_constraints, domain, opts)
+
+      if is_map(serialized) do
+        Map.put(serialized, :type, union_type)
+      else
+        %{type: union_type, value: serialized}
+      end
+    else
+      %{type: union_type, value: inner}
+    end
+  end
+
   def serialize_value(value, type, constraints, domain, opts) do
     {type, constraints} = flatten_new_type(type, constraints || [])
     opts = [skip_only_primary_key?: false, top_level?: false] |> Keyword.merge(opts)

--- a/test/ash_ai/serializer_test.exs
+++ b/test/ash_ai/serializer_test.exs
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAi.SerializerTest do
+  use ExUnit.Case, async: true
+
+  defmodule EmbeddedItem do
+    use Ash.Resource, data_layer: :embedded
+
+    attributes do
+      attribute :label, :string, public?: true, allow_nil?: false
+    end
+
+    actions do
+      defaults [:create]
+      default_accept [:label]
+    end
+  end
+
+  defmodule UnionResource do
+    use Ash.Resource,
+      domain: AshAi.SerializerTest.TestDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :name, :string, public?: true
+
+      attribute :data, :union,
+        public?: true,
+        constraints: [
+          types: [
+            embedded: [type: EmbeddedItem, constraints: []]
+          ]
+        ]
+    end
+
+    actions do
+      defaults [:read, :create]
+      default_accept [:name, :data]
+    end
+  end
+
+  defmodule TestDomain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource UnionResource
+    end
+
+    tools do
+      tool :read_union_resources, UnionResource, :read
+    end
+  end
+
+  describe "Tools.execute with union-typed attributes" do
+    test "serializes union containing embedded resource to JSON" do
+      # Mirrors the real failure: a resource with a union attribute whose inner
+      # value is a struct. Without the Ash.Union serializer clause, the struct
+      # passes through unserialized and Jason.encode! inside Tools.execute
+      # raises Protocol.UndefinedError.
+      UnionResource
+      |> Ash.Changeset.for_create(:create, %{
+        name: "test",
+        data: %Ash.Union{type: :embedded, value: %EmbeddedItem{label: "hello"}}
+      })
+      |> Ash.create!()
+
+      [tool] =
+        AshAi.exposed_tools(actions: [{UnionResource, :*}])
+
+      assert {:ok, json, _result} = AshAi.Tools.execute(tool, %{}, %{})
+
+      decoded = Jason.decode!(json)
+      [item] = decoded
+      assert item["data"]["type"] == "embedded"
+      assert item["data"]["label"] == "hello"
+      assert item["name"] == "test"
+    end
+  end
+end


### PR DESCRIPTION
`Ash.Union` structs containing resource values passed through the serializer unhandled, causing `Jason.encode!` in `Tools.execute` to raise `Protocol.UndefinedError` for the inner struct.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
