### PR TITLE
Honor the `identity:` tool option in update/destroy schemas

### DIFF
--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -61,6 +61,33 @@ defmodule AshAi do
         do: true
 
     def has_meta?(_), do: false
+
+    @doc """
+    Resolves the attribute keys used to address a record for update/destroy tools.
+
+    Mirrors the `identity:` tool option so schema generation and execution stay in sync:
+
+      * `false` - no identifier keys (the caller adds no filter / no schema property)
+      * `nil` - the resource's primary key (the default)
+      * a name - the keys of the named identity
+    """
+    def identity_keys(_resource, false), do: []
+
+    def identity_keys(resource, nil), do: Ash.Resource.Info.primary_key(resource)
+
+    def identity_keys(resource, name) do
+      resource
+      |> Ash.Resource.Info.identities()
+      |> Enum.find(&(&1.name == name))
+      |> case do
+        nil ->
+          raise ArgumentError,
+                "No identity named #{inspect(name)} found on #{inspect(resource)}"
+
+        identity ->
+          identity.keys
+      end
+    end
   end
 
   defmodule McpResource do

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -349,7 +349,7 @@ defmodule AshAi.Tool.Execution do
 
   defp identity_filter(nil, resource, arguments) do
     resource
-    |> Ash.Resource.Info.primary_key()
+    |> AshAi.Tool.identity_keys(nil)
     |> Enum.reduce(nil, fn key, expr ->
       value = Map.get(arguments, to_string(key))
 
@@ -363,9 +363,7 @@ defmodule AshAi.Tool.Execution do
 
   defp identity_filter(identity, resource, arguments) do
     resource
-    |> Ash.Resource.Info.identities()
-    |> Enum.find(&(&1.name == identity))
-    |> Map.get(:keys)
+    |> AshAi.Tool.identity_keys(identity)
     |> Enum.map(fn key ->
       {key, Map.get(arguments, to_string(key))}
     end)

--- a/lib/ash_ai/tool/schema.ex
+++ b/lib/ash_ai/tool/schema.ex
@@ -20,12 +20,17 @@ defmodule AshAi.Tool.Schema do
           resource: resource,
           action: action,
           action_parameters: action_parameters,
-          arguments: tool_arguments
+          arguments: tool_arguments,
+          identity: identity
         },
         opts \\ []
       ) do
     strict? = Keyword.get(opts, :strict?, true)
-    for_action(domain, resource, action, action_parameters, tool_arguments, strict?: strict?)
+
+    for_action(domain, resource, action, action_parameters, tool_arguments,
+      strict?: strict?,
+      identity: identity
+    )
   end
 
   @doc """
@@ -40,6 +45,7 @@ defmodule AshAi.Tool.Schema do
         opts \\ []
       ) do
     strict? = Keyword.get(opts, :strict?, true)
+    identity = Keyword.get(opts, :identity, nil)
 
     attributes =
       if action.type in [:action, :read] do
@@ -112,7 +118,8 @@ defmodule AshAi.Tool.Schema do
       type: :object,
       properties:
         add_action_specific_properties(props_with_input, resource, action, action_parameters,
-          strict?: strict?
+          strict?: strict?,
+          identity: identity
         ),
       required: Map.keys(props_with_input),
       additionalProperties: false
@@ -418,11 +425,17 @@ defmodule AshAi.Tool.Schema do
          resource,
          %{type: type},
          _action_parameters,
-         _opts
+         opts
        )
        when type in [:update, :destroy] do
-    pkey =
-      Map.new(Ash.Resource.Info.primary_key(resource), fn key ->
+    identity = Keyword.get(opts, :identity, nil)
+
+    # Mirror `AshAi.Tool.Execution.identity_filter/3`: address records by the
+    # configured identity (or the primary key by default, or nothing when `false`).
+    identity_properties =
+      resource
+      |> AshAi.Tool.identity_keys(identity)
+      |> Map.new(fn key ->
         value =
           Ash.Resource.Info.attribute(resource, key)
           |> AshAi.OpenApi.resource_write_attribute_type(resource, type)
@@ -430,7 +443,7 @@ defmodule AshAi.Tool.Schema do
         {key, value}
       end)
 
-    Map.merge(properties, pkey)
+    Map.merge(properties, identity_properties)
   end
 
   defp add_action_specific_properties(properties, _resource, _action, _action_parameters, _opts),

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -5,7 +5,7 @@
 defmodule AshAi.ToolTest do
   use ExUnit.Case, async: true
 
-  alias __MODULE__.{TestDomain, TestResource}
+  alias __MODULE__.{IdentityDomain, IdentityResource, TestDomain, TestResource}
 
   defmodule TestResource do
     use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets
@@ -45,6 +45,116 @@ defmodule AshAi.ToolTest do
              "openai/toolInvocation/invoking" => "Loading test resources…",
              "openai/toolInvocation/invoked" => "Test resources loaded."
            }
+    end
+  end
+
+  defmodule IdentityResource do
+    use Ash.Resource, domain: IdentityDomain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      integer_primary_key :id, writable?: true
+      attribute :public_id, :string, public?: true, allow_nil?: false
+      attribute :name, :string, public?: true
+    end
+
+    identities do
+      identity :public_id, [:public_id], pre_check_with: IdentityDomain
+    end
+
+    actions do
+      defaults [:read, :create, :destroy]
+      default_accept [:id, :public_id, :name]
+
+      update :update do
+        primary? true
+        accept [:name]
+      end
+    end
+  end
+
+  defmodule IdentityDomain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource IdentityResource
+    end
+
+    tools do
+      # Default: addresses records by the primary key
+      tool :update_by_pk, IdentityResource, :update
+
+      # Custom identity: addresses records by the `public_id` unique identity
+      tool :update_by_public_id, IdentityResource, :update, identity: :public_id
+
+      # Disabled: no identifier in the schema at all
+      tool :update_no_identity, IdentityResource, :update, identity: false
+    end
+  end
+
+  describe "identity in update/destroy schemas" do
+    defp identity_tool(name) do
+      AshAi.list_tools(actions: [{IdentityResource, [:update]}], strict: false)
+      |> Enum.find(&(&1.name == to_string(name)))
+    end
+
+    test "default (no identity:) includes the primary key" do
+      props = identity_tool(:update_by_pk).parameter_schema["properties"]
+
+      assert Map.has_key?(props, "id")
+      refute Map.has_key?(props, "public_id")
+    end
+
+    test "identity: <non-pk identity> includes the identity key, not the primary key" do
+      props = identity_tool(:update_by_public_id).parameter_schema["properties"]
+
+      assert Map.has_key?(props, "public_id")
+      refute Map.has_key?(props, "id")
+    end
+
+    test "identity: false includes neither the primary key nor an identity" do
+      props = identity_tool(:update_no_identity).parameter_schema["properties"]
+
+      refute Map.has_key?(props, "id")
+      refute Map.has_key?(props, "public_id")
+    end
+  end
+
+  describe "identity in update execution" do
+    setup do
+      records =
+        for i <- 1..2 do
+          IdentityResource
+          |> Ash.Changeset.for_create(:create, %{
+            id: i,
+            public_id: "pub-#{i}",
+            name: "Name #{i}"
+          })
+          |> Ash.create!(domain: IdentityDomain)
+        end
+
+      %{records: records}
+    end
+
+    test "update tool with identity: :public_id resolves and updates by public_id only" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{IdentityResource, [:update]}],
+          strict: false
+        )
+
+      {:ok, _json, updated} =
+        registry["update_by_public_id"].(
+          %{"public_id" => "pub-2", "input" => %{"name" => "Renamed"}},
+          context()
+        )
+
+      assert updated.id == 2
+      assert updated.public_id == "pub-2"
+      assert updated.name == "Renamed"
+
+      # The other record is untouched
+      other = Ash.get!(IdentityResource, 1, domain: IdentityDomain)
+      assert other.name == "Name 1"
     end
   end
 


### PR DESCRIPTION
Hello, I had an agent explore adding ash_ai to a spike I was working through. The agent told me that it was unable to use my public id fields to wire up update/delete actions due to the `:identity` option not being wired through properly to the schema generation.

I have validated the agent's claims and they seem legit, but note that this PR and the following blurb are agent generated.

The `identity:` tool option is honored at execution time (`AshAi.Tool.Execution.identity_filter/3`) but was dropped during schema generation, so update/destroy tools always demanded the resource's primary key regardless of `identity:`. For a public_id-only API surface this is unusable: agents only ever see the identity from reads and can never supply the integer primary key.

This finishes wiring the option through schema generation, mirroring the execution path:

- `false` -> no identifier property
- `nil`   -> the primary key (unchanged default)
- name    -> the named identity's keys

A shared `AshAi.Tool.identity_keys/2` helper is extracted so schema generation and execution resolve identity keys the same way and can't drift. Backward compatible: the default remains the primary key.
