### PR TITLE
feat: update mdex

### DIFF
--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -444,12 +444,6 @@ if Code.ensure_loaded?(Igniter) do
       end)
       |> Igniter.Project.Config.configure(
         "config.exs",
-        :mdex_native,
-        [:syntax_highlighter],
-        :lumis
-      )
-      |> Igniter.Project.Config.configure(
-        "config.exs",
         otp_app,
         [Oban, :queues, :chat_responses, :limit],
         10
@@ -459,6 +453,12 @@ if Code.ensure_loaded?(Igniter) do
         otp_app,
         [Oban, :queues, :conversations, :limit],
         10
+      )
+      |> Igniter.Project.Config.configure(
+        "config.exs",
+        :mdex_native,
+        [:syntax_highlighter],
+        :lumis
       )
     end
 

--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -102,6 +102,7 @@ defmodule Mix.Tasks.AshAi.Gen.Chat.Docs do
     * `ash_phoenix` - for forms and code interfaces
     * `ash_oban` - for background job processing
     * `mdex` - for Markdown rendering in the UI
+    * `lumis` - for syntax highlighting in rendered Markdown code blocks
 
     ### Domain Module (`YourApp.Chat`)
 
@@ -181,7 +182,7 @@ defmodule Mix.Tasks.AshAi.Gen.Chat.Docs do
     The generator adds to your app config:
 
     * `config/runtime.exs` - ReqLLM API key for the selected provider
-    * `config/config.exs` - Oban queue configuration (`chat_responses` and `conversations`, limit 10 each)
+    * `config/config.exs` - Oban queue configuration (`chat_responses` and `conversations`, limit 10 each) and MDEx native syntax highlighting via Lumis
 
     ### Provider Models
 
@@ -406,9 +407,16 @@ if Code.ensure_loaded?(Igniter) do
           {Igniter.Project.Deps.add_dep(igniter, {:mdex, "~> 0.7"}), true}
         end
 
+      {igniter, install_lumis?} =
+        if Igniter.Project.Deps.has_dep?(igniter, :lumis) do
+          {igniter, false}
+        else
+          {Igniter.Project.Deps.add_dep(igniter, {:lumis, "~> 0.1"}), true}
+        end
+
       igniter
       |> then(fn igniter ->
-        if install_ash_phoenix? || install_ash_oban? || install_mdex? do
+        if install_ash_phoenix? || install_ash_oban? || install_mdex? || install_lumis? do
           if igniter.assigns[:test_mode?] do
             igniter
           else
@@ -434,6 +442,12 @@ if Code.ensure_loaded?(Igniter) do
           igniter
         end
       end)
+      |> Igniter.Project.Config.configure(
+        "config.exs",
+        :mdex_native,
+        [:syntax_highlighter],
+        :lumis
+      )
       |> Igniter.Project.Config.configure(
         "config.exs",
         otp_app,

--- a/test/mix/tasks/ash_ai.gen.conversation_test.exs
+++ b/test/mix/tasks/ash_ai.gen.conversation_test.exs
@@ -237,4 +237,21 @@ defmodule Mix.Tasks.AshAi.Gen.ChatTest do
     refute component_content =~ "defp normalize_tool_call_arguments("
     refute component_content =~ "defp tool_result_preview("
   end
+
+  test "generated UI includes Lumis and MDEx native config", %{argv: argv} do
+    argv = argv ++ ["--live", "--live-component"]
+
+    phx_test_project()
+    |> Igniter.compose_task("ash_ai.gen.chat", argv)
+    |> assert_has_patch("mix.exs", """
+    + |{:mdex, "~> 0.7"}
+    """)
+    |> assert_has_patch("mix.exs", """
+    + |{:lumis, "~> 0.1"}
+    """)
+    |> assert_has_patch("config/config.exs", """
+    + |config :mdex_native, syntax_highlighter: :lumis
+    """)
+    |> apply_igniter!()
+  end
 end


### PR DESCRIPTION
Latest version requires additional steps to enable syntax highlighting.

https://github.com/leandrocp/mdex/blob/main/CHANGELOG.md#syntax-highlighting-migration-guide

The output is the same because `:lumis` was already a dep, it's just more explicit now.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
