### PR TITLE
feat: add get_by argument to tool definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ defmodule MyApp.Blog do
 
   tools do
     tool :read_posts, MyApp.Blog.Post, :read
+    tool :get_post_by_id, MyApp.Blog.Post, :read, get_by: :id
     tool :create_post, MyApp.Blog.Post, :create
     tool :publish_post, MyApp.Blog.Post, :publish
     tool :read_comments, MyApp.Blog.Comment, :read
@@ -207,6 +208,7 @@ defmodule MyApp.Blog.Post do
 
   tools do
     tool :read_posts, :read
+    tool :get_post_by_slug, :read, get_by: :slug
     tool :create_post, :create
   end
 end
@@ -252,6 +254,7 @@ Resources are exposed via the MCP server at `/mcp` and can be accessed by MCP-co
 
 **Important**: Tools have different access levels for different operations:
 - **Filtering/Sorting/Aggregation**: Only public attributes (`public?: true`) can be used
+- **Single-record lookup**: Use `get_by` on read tools to require public, filterable lookup fields and return one record
 - **Arguments**: Only public action arguments are exposed
 - **Response data**: Public attributes are returned by default
 - **Loading data**: Use the `load` option to include relationships, calculations, or additional attributes (including private ones) in responses
@@ -261,7 +264,10 @@ Example:
 tools do
   # Returns only public attributes
   tool :read_posts, MyApp.Blog.Post, :read
-  
+
+  # Returns one post by ID instead of a list of results
+  tool :get_post_by_id, MyApp.Blog.Post, :read, get_by: :id
+
   # Returns public attributes AND loaded relationships/calculations
   # Note: loaded fields can include private attributes
   tool :read_posts_with_details, MyApp.Blog.Post, :read,

--- a/documentation/dsls/DSL-AshAi.md
+++ b/documentation/dsls/DSL-AshAi.md
@@ -40,6 +40,10 @@ tool :list_artists, Artist, :read
 ```
 
 ```
+tool :get_artist_by_id, Artist, :read, get_by: :id
+```
+
+```
 tool :create_artist, Artist, :create, description: "Create a new artist"
 ```
 
@@ -74,6 +78,7 @@ tool :list_artists, Artist, :read, ui: "ui://artists/list.html"
 | [`async`](#tools-tool-async){: #tools-tool-async } | `boolean` | `true` |  |
 | [`description`](#tools-tool-description){: #tools-tool-description } | `String.t` |  | A description for the tool. Defaults to the action's description. |
 | [`identity`](#tools-tool-identity){: #tools-tool-identity } | `atom` |  | The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely. |
+| [`get_by`](#tools-tool-get_by){: #tools-tool-get_by } | `atom \| list(atom)` |  | For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable. |
 | [`_meta`](#tools-tool-_meta){: #tools-tool-_meta } | `any` | `%{}` | Optional metadata map for tool integrations. Supports provider-specific extensions like OpenAI metadata. Keys and values should be strings to comply with JSON-RPC serialization. |
 | [`ui`](#tools-tool-ui){: #tools-tool-ui } | `atom \| String.t` |  | The `mcp_ui_resource` name (atom) or a `ui://` URI string for MCP Apps. Shortcut for setting `_meta.ui.resourceUri`. When an atom is given, the URI is resolved from the matching `mcp_ui_resource` declaration. |
 

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -33,6 +33,7 @@ defmodule AshAi do
       :async,
       :domain,
       :identity,
+      :get_by,
       :description,
       :action_parameters,
       :arguments,
@@ -87,6 +88,45 @@ defmodule AshAi do
 
         identity ->
           identity.keys
+      end
+    end
+
+    @doc """
+    Resolves the fields used to address a single record for read tools.
+    """
+    def get_by_fields(_resource, nil), do: []
+
+    def get_by_fields(resource, get_by) do
+      get_by
+      |> List.wrap()
+      |> Enum.map(fn field_name ->
+        field = Ash.Resource.Info.field(resource, field_name)
+
+        case validate_get_by_field(field, field_name, resource) do
+          :ok -> field
+          {:error, message} -> raise ArgumentError, message
+        end
+      end)
+    end
+
+    @doc """
+    Checks that a field resolved for `get_by` exists and is public and filterable.
+    """
+    def validate_get_by_field(nil, field_name, resource) do
+      {:error,
+       "`#{inspect(field_name)}` is not a valid attribute, calculation or aggregate on #{inspect(resource)}"}
+    end
+
+    def validate_get_by_field(field, field_name, _resource) do
+      cond do
+        !Map.get(field, :public?, false) ->
+          {:error, "`#{inspect(field_name)}` is not public, so it cannot be used in `get_by`"}
+
+        !Map.get(field, :filterable?, false) ->
+          {:error, "`#{inspect(field_name)}` is not filterable, so it cannot be used in `get_by`"}
+
+        true ->
+          :ok
       end
     end
   end

--- a/lib/ash_ai/dsl.ex
+++ b/lib/ash_ai/dsl.ex
@@ -96,6 +96,11 @@ defmodule AshAi.Dsl do
       doc:
         "The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely."
     ],
+    get_by: [
+      type: {:or, [:atom, {:list, :atom}]},
+      doc:
+        "For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable."
+    ],
     _meta: [
       type: :any,
       default: %{},
@@ -217,6 +222,7 @@ defmodule AshAi.Dsl do
     """,
     examples: [
       ~s(tool :list_artists, Artist, :read),
+      ~s(tool :get_artist_by_id, Artist, :read, get_by: :id),
       ~s(tool :create_artist, Artist, :create, description: "Create a new artist"),
       ~s(tool :update_artist, Artist, :update, identity: :id, load: [:albums]),
       ~s|tool :get_board, Board, :read, _meta: %{"openai/outputTemplate" => "ui://widget/kanban-board.html", "openai/toolInvocation/invoking" => "Preparing the board…", "openai/toolInvocation/invoked" => "Board ready."}|,

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -32,6 +32,7 @@ defmodule AshAi.Tool.Execution do
           action: action,
           load: load,
           identity: identity,
+          get_by: get_by,
           arguments: tool_arguments
         },
         client_arguments,
@@ -62,7 +63,7 @@ defmodule AshAi.Tool.Execution do
       input = Map.take(client_input, valid_action_inputs(resource, action))
 
       case action.type do
-        :read -> run_read(resource, action, arguments, input, opts, exec_ctx)
+        :read -> run_read(resource, action, arguments, input, opts, get_by, exec_ctx)
         :create -> run_create(resource, action, input, opts, exec_ctx)
         :update -> run_update(resource, action, arguments, input, opts, identity, exec_ctx)
         :destroy -> run_destroy(resource, action, arguments, input, opts, identity, exec_ctx)
@@ -86,7 +87,7 @@ defmodule AshAi.Tool.Execution do
     ]
   end
 
-  defp run_read(resource, action, arguments, input, opts, ctx) do
+  defp run_read(resource, action, arguments, input, opts, nil, ctx) do
     sort = build_sort(arguments["sort"])
     limit = build_limit(arguments["limit"], action.pagination)
 
@@ -99,6 +100,14 @@ defmodule AshAi.Tool.Execution do
       |> Ash.Query.for_read(action.name, input, opts)
 
     execute_read(query, action, arguments["result_type"] || "run_query", ctx)
+  end
+
+  defp run_read(resource, action, arguments, input, opts, get_by, ctx) do
+    resource
+    |> Ash.Query.for_read(action.name, input, opts)
+    |> Ash.Query.do_filter(get_by_filter(get_by, arguments))
+    |> Ash.read_one!(Keyword.merge(opts, load: ctx.load, not_found_error?: true))
+    |> serialize_record(resource, ctx)
   end
 
   defp build_sort(sort) when is_list(sort) do
@@ -252,12 +261,7 @@ defmodule AshAi.Tool.Execution do
     resource
     |> Ash.Changeset.for_create(action.name, input, opts)
     |> Ash.create!(load: ctx.load)
-    |> then(fn result ->
-      result
-      |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, load: ctx.load)
-      |> Jason.encode!()
-      |> then(&{:ok, &1, result})
-    end)
+    |> serialize_record(resource, ctx)
   end
 
   defp run_update(resource, action, arguments, input, opts, identity, ctx) do
@@ -280,10 +284,7 @@ defmodule AshAi.Tool.Execution do
     )
     |> case do
       %Ash.BulkResult{status: :success, records: [result]} ->
-        result
-        |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, load: ctx.load)
-        |> Jason.encode!()
-        |> then(&{:ok, &1, result})
+        serialize_record(result, resource, ctx)
 
       %Ash.BulkResult{status: :success, records: []} ->
         raise Ash.Error.to_error_class(Ash.Error.Query.NotFound.exception(primary_key: filter))
@@ -310,14 +311,18 @@ defmodule AshAi.Tool.Execution do
     )
     |> case do
       %Ash.BulkResult{status: :success, records: [result]} ->
-        result
-        |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, load: ctx.load)
-        |> Jason.encode!()
-        |> then(&{:ok, &1, result})
+        serialize_record(result, resource, ctx)
 
       %Ash.BulkResult{status: :success, records: []} ->
         raise Ash.Error.to_error_class(Ash.Error.Query.NotFound.exception(primary_key: filter))
     end
+  end
+
+  defp serialize_record(result, resource, ctx) do
+    result
+    |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, load: ctx.load)
+    |> Jason.encode!()
+    |> then(&{:ok, &1, result})
   end
 
   defp run_generic(resource, action, input, opts, ctx) do
@@ -362,6 +367,19 @@ defmodule AshAi.Tool.Execution do
     |> AshAi.Tool.identity_keys(identity)
     |> Enum.map(fn key ->
       {key, Map.get(arguments, to_string(key))}
+    end)
+  end
+
+  # The get_by fields were already validated at compile time and schema build,
+  # so only their names are needed here.
+  defp get_by_filter(get_by, arguments) do
+    get_by
+    |> List.wrap()
+    |> Map.new(fn field_name ->
+      case Map.get(arguments, to_string(field_name)) do
+        nil -> throw({:tool_error, "Missing required get_by argument: #{field_name}"})
+        value -> {field_name, value}
+      end
     end)
   end
 

--- a/lib/ash_ai/tool/schema.ex
+++ b/lib/ash_ai/tool/schema.ex
@@ -21,7 +21,8 @@ defmodule AshAi.Tool.Schema do
           action: action,
           action_parameters: action_parameters,
           arguments: tool_arguments,
-          identity: identity
+          identity: identity,
+          get_by: get_by
         } = tool,
         opts \\ []
       ) do
@@ -30,6 +31,7 @@ defmodule AshAi.Tool.Schema do
     for_action(domain, resource, action, action_parameters, tool_arguments,
       strict?: strict?,
       identity: identity,
+      get_by: get_by,
       full_filter_schema?: Map.get(tool, :full_filter_schema?, false)
     )
   end
@@ -47,6 +49,12 @@ defmodule AshAi.Tool.Schema do
       ) do
     strict? = Keyword.get(opts, :strict?, true)
     identity = Keyword.get(opts, :identity, nil)
+    get_by = Keyword.get(opts, :get_by, nil)
+
+    get_by_fields =
+      if get_by && action.type == :read do
+        AshAi.Tool.get_by_fields(resource, get_by)
+      end
 
     attributes =
       if action.type in [:action, :read] do
@@ -121,9 +129,10 @@ defmodule AshAi.Tool.Schema do
         add_action_specific_properties(props_with_input, resource, action, action_parameters,
           strict?: strict?,
           identity: identity,
+          get_by_fields: get_by_fields,
           full_filter_schema?: Keyword.get(opts, :full_filter_schema?, false)
         ),
-      required: Map.keys(props_with_input),
+      required: Map.keys(props_with_input) ++ Enum.map(get_by_fields || [], & &1.name),
       additionalProperties: false
     }
     |> Jason.encode!()
@@ -246,9 +255,69 @@ defmodule AshAi.Tool.Schema do
          action_parameters,
          opts
        ) do
-    strict? = Keyword.get(opts, :strict?, true)
-    {allowed_result_types, action_parameters} = extract_result_types(action_parameters)
+    case Keyword.get(opts, :get_by_fields) do
+      nil ->
+        strict? = Keyword.get(opts, :strict?, true)
+        {allowed_result_types, action_parameters} = extract_result_types(action_parameters)
 
+        read_query_properties(
+          properties,
+          resource,
+          pagination,
+          action_parameters,
+          strict?,
+          allowed_result_types,
+          opts
+        )
+
+      get_by_fields ->
+        get_by_properties =
+          Map.new(get_by_fields, fn field ->
+            {field.name, AshAi.OpenApi.resource_write_attribute_type(field, resource, :create)}
+          end)
+
+        Map.merge(properties, get_by_properties)
+    end
+  end
+
+  defp add_action_specific_properties(
+         properties,
+         resource,
+         %{type: type},
+         _action_parameters,
+         opts
+       )
+       when type in [:update, :destroy] do
+    identity = Keyword.get(opts, :identity, nil)
+
+    # Mirror `AshAi.Tool.Execution.identity_filter/3`: address records by the
+    # configured identity (or the primary key by default, or nothing when `false`).
+    identity_properties =
+      resource
+      |> AshAi.Tool.identity_keys(identity)
+      |> Map.new(fn key ->
+        value =
+          Ash.Resource.Info.attribute(resource, key)
+          |> AshAi.OpenApi.resource_write_attribute_type(resource, type)
+
+        {key, value}
+      end)
+
+    Map.merge(properties, identity_properties)
+  end
+
+  defp add_action_specific_properties(properties, _resource, _action, _action_parameters, _opts),
+    do: properties
+
+  defp read_query_properties(
+         properties,
+         resource,
+         pagination,
+         action_parameters,
+         strict?,
+         allowed_result_types,
+         opts
+       ) do
     aggregate_fields =
       Ash.Resource.Info.fields(resource, [
         :attributes,
@@ -484,35 +553,6 @@ defmodule AshAi.Tool.Schema do
       end
     end)
   end
-
-  defp add_action_specific_properties(
-         properties,
-         resource,
-         %{type: type},
-         _action_parameters,
-         opts
-       )
-       when type in [:update, :destroy] do
-    identity = Keyword.get(opts, :identity, nil)
-
-    # Mirror `AshAi.Tool.Execution.identity_filter/3`: address records by the
-    # configured identity (or the primary key by default, or nothing when `false`).
-    identity_properties =
-      resource
-      |> AshAi.Tool.identity_keys(identity)
-      |> Map.new(fn key ->
-        value =
-          Ash.Resource.Info.attribute(resource, key)
-          |> AshAi.OpenApi.resource_write_attribute_type(resource, type)
-
-        {key, value}
-      end)
-
-    Map.merge(properties, identity_properties)
-  end
-
-  defp add_action_specific_properties(properties, _resource, _action, _action_parameters, _opts),
-    do: properties
 
   defp add_input_for_fields(sort_obj, resource) do
     resource

--- a/lib/ash_ai/transformers/resource_tools.ex
+++ b/lib/ash_ai/transformers/resource_tools.ex
@@ -50,7 +50,81 @@ defmodule AshAi.Transformers.ResourceTools do
           dsl
       end
     end)
+    |> validate_tools!(module, resource_dsl?)
     |> then(&{:ok, &1})
+  end
+
+  defp validate_tools!(dsl_state, module, resource_dsl?) do
+    dsl_state
+    |> Transformer.get_entities([:tools])
+    |> Enum.each(&validate_get_by!(&1, dsl_state, module, resource_dsl?))
+
+    dsl_state
+  end
+
+  defp validate_get_by!(%{get_by: nil}, _dsl_state, _module, _resource_dsl?), do: :ok
+
+  defp validate_get_by!(tool, dsl_state, module, resource_dsl?) do
+    case fetch_action(tool, dsl_state, resource_dsl?) do
+      :deferred ->
+        :ok
+
+      nil ->
+        raise Spark.Error.DslError,
+          module: module,
+          path: [:tools, tool.name, :action],
+          message:
+            "Tool `#{tool.name}` references action `#{tool.action}`, but no such action exists."
+
+      %{type: :read} ->
+        validate_get_by_fields!(tool, dsl_state, module, resource_dsl?)
+
+      _action ->
+        raise_get_by_error!(tool, module, "`get_by` can only be used with read tools.")
+    end
+  end
+
+  # Resource-level tools point at the module being compiled, so its own
+  # dsl_state is the source of truth (this transformer runs after Ash has
+  # materialized default actions). Domain-level tools reference other modules,
+  # which may not be compiled yet — those are skipped here and the same checks
+  # run again when the tool's schema is built.
+  defp fetch_action(tool, dsl_state, true) do
+    Ash.Resource.Info.action(dsl_state, tool.action)
+  end
+
+  defp fetch_action(tool, _dsl_state, false) do
+    case Code.ensure_loaded(tool.resource) do
+      {:module, resource} ->
+        if Ash.Resource.Info.resource?(resource) do
+          Ash.Resource.Info.action(resource, tool.action)
+        end
+
+      {:error, _reason} ->
+        :deferred
+    end
+  end
+
+  defp validate_get_by_fields!(tool, dsl_state, module, resource_dsl?) do
+    source = if resource_dsl?, do: dsl_state, else: tool.resource
+
+    tool.get_by
+    |> List.wrap()
+    |> Enum.each(fn field_name ->
+      field = Ash.Resource.Info.field(source, field_name)
+
+      case AshAi.Tool.validate_get_by_field(field, field_name, tool.resource) do
+        :ok -> :ok
+        {:error, message} -> raise_get_by_error!(tool, module, message)
+      end
+    end)
+  end
+
+  defp raise_get_by_error!(tool, module, message) do
+    raise Spark.Error.DslError,
+      module: module,
+      path: [:tools, tool.name, :get_by],
+      message: message
   end
 
   defp resource_dsl?(module) do

--- a/test/ash_ai/resource_tools_test.exs
+++ b/test/ash_ai/resource_tools_test.exs
@@ -31,6 +31,7 @@ defmodule AshAi.ResourceToolsTest do
 
     tools do
       tool(:resource_read, :read)
+      tool(:resource_get_by_id, :read, get_by: :id)
       tool(:resource_create, :create)
     end
   end
@@ -91,6 +92,17 @@ defmodule AshAi.ResourceToolsTest do
       assert tool.action == :read
     end
 
+    test "tool :name, :action supports get_by" do
+      tool =
+        ResourceToolResource
+        |> AshAi.Info.tools()
+        |> Enum.find(&(&1.name == :resource_get_by_id))
+
+      assert tool.resource == ResourceToolResource
+      assert tool.action == :read
+      assert tool.get_by == :id
+    end
+
     test "resource-level tools reject explicit resource argument" do
       module =
         Module.concat(__MODULE__, :"InvalidResourceTool#{System.unique_integer([:positive])}")
@@ -142,6 +154,67 @@ defmodule AshAi.ResourceToolsTest do
         )
       end
     end
+
+    test "domain-level get_by tools tolerate resources compiled later" do
+      domain =
+        Module.concat(
+          __MODULE__,
+          :"DeferredGetByDomain#{System.unique_integer([:positive])}"
+        )
+
+      resource =
+        Module.concat(
+          __MODULE__,
+          :"DeferredGetByResource#{System.unique_integer([:positive])}"
+        )
+
+      assert {:module, ^domain, _binary, _term} =
+               Module.create(
+                 domain,
+                 quote do
+                   use Ash.Domain, extensions: [AshAi], validate_config_inclusion?: false
+
+                   resources do
+                     resource unquote(resource)
+                   end
+
+                   tools do
+                     tool(:get_deferred_resource, unquote(resource), :read, get_by: :id)
+                   end
+                 end,
+                 Macro.Env.location(__ENV__)
+               )
+
+      assert {:module, ^resource, _binary, _term} =
+               Module.create(
+                 resource,
+                 quote do
+                   use Ash.Resource,
+                     domain: unquote(domain),
+                     extensions: [AshAi],
+                     data_layer: Ash.DataLayer.Ets,
+                     validate_domain_inclusion?: false
+
+                   attributes do
+                     uuid_v7_primary_key(:id, writable?: true)
+                   end
+
+                   actions do
+                     defaults([:read])
+                   end
+                 end,
+                 Macro.Env.location(__ENV__)
+               )
+
+      tool =
+        domain
+        |> AshAi.Info.tools()
+        |> Enum.find(&(&1.name == :get_deferred_resource))
+
+      assert tool.resource == resource
+      assert tool.action == :read
+      assert tool.get_by == :id
+    end
   end
 
   describe "AshAi.exposed_tools/1 discovery" do
@@ -151,7 +224,12 @@ defmodule AshAi.ResourceToolsTest do
       assert tools
              |> Enum.map(& &1.name)
              |> MapSet.new() ==
-               MapSet.new([:resource_read, :resource_create, :domain_create_alias])
+               MapSet.new([
+                 :resource_read,
+                 :resource_get_by_id,
+                 :resource_create,
+                 :domain_create_alias
+               ])
     end
 
     test "actions filter by specific action keeps matching tools from both levels" do

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -36,6 +36,13 @@ defmodule AshAi.ToolTest do
     tools do
       tool :read_test_resources, TestResource, :read, load: [:internal_status]
 
+      tool :get_test_resource_by_id, TestResource, :read,
+        get_by: :id,
+        load: [:internal_status]
+
+      tool :get_test_resource_by_name_and_email, TestResource, :read,
+        get_by: [:public_name, :public_email]
+
       tool :read_test_resources_full_filter, TestResource, :read, full_filter_schema?: true
 
       tool :read_test_resources_with_meta,
@@ -180,7 +187,11 @@ defmodule AshAi.ToolTest do
       {_tools, registry} =
         AshAi.build_tools_and_registry(actions: [{TestResource, :*}], strict: false)
 
-      {:ok, json, [fetched]} = registry["read_test_resources"].(%{}, context())
+      {:ok, json, [fetched]} =
+        registry["read_test_resources"].(
+          %{"filter" => %{"field" => "id", "operator" => "eq", "value" => resource.id}},
+          context()
+        )
 
       assert fetched.id == resource.id
       assert fetched.public_name == "John Doe"
@@ -198,6 +209,109 @@ defmodule AshAi.ToolTest do
 
       {:ok, json, _raw} = registry["read_test_resources"].(nil, context())
       assert is_binary(json)
+    end
+  end
+
+  describe "get_by read tools" do
+    setup do
+      id = Ash.UUIDv7.generate()
+
+      resource =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{
+          id: id,
+          public_name: "Jane #{id}",
+          public_email: "jane-#{id}@example.com",
+          private_notes: "Private lookup notes",
+          internal_status: "reviewed"
+        })
+        |> Ash.create!(domain: TestDomain)
+
+      %{resource: resource}
+    end
+
+    test "schema exposes lookup fields and not list-query controls" do
+      tool =
+        [actions: [{TestResource, [:read]}], tools: [:get_test_resource_by_id], strict: false]
+        |> AshAi.list_tools()
+        |> hd()
+
+      props = tool.parameter_schema["properties"]
+
+      assert Map.has_key?(props, "id")
+      assert tool.parameter_schema["required"] == ["id"]
+
+      refute Map.has_key?(props, "filter")
+      refute Map.has_key?(props, "sort")
+      refute Map.has_key?(props, "limit")
+      refute Map.has_key?(props, "offset")
+      refute Map.has_key?(props, "result_type")
+    end
+
+    test "executes by a single lookup field and returns one record", %{resource: resource} do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      {:ok, json, fetched} =
+        registry["get_test_resource_by_id"].(%{"id" => resource.id}, context())
+
+      assert fetched.id == resource.id
+
+      assert json ==
+               "{\"id\":\"#{resource.id}\",\"public_name\":\"Jane #{resource.id}\",\"public_email\":\"jane-#{resource.id}@example.com\",\"internal_status\":\"reviewed\"}"
+    end
+
+    test "executes by a composite lookup", %{resource: resource} do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_name_and_email],
+          strict: false
+        )
+
+      {:ok, _json, fetched} =
+        registry["get_test_resource_by_name_and_email"].(
+          %{
+            "public_name" => resource.public_name,
+            "public_email" => resource.public_email
+          },
+          context()
+        )
+
+      assert fetched.id == resource.id
+    end
+
+    test "returns a tool error when a lookup argument is missing" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:error, "Missing required get_by argument: id"} =
+               registry["get_test_resource_by_id"].(%{}, context())
+    end
+
+    test "returns a tool error when no record matches" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:error, message} =
+               registry["get_test_resource_by_id"].(
+                 %{"id" => "0197b375-4daa-7112-a9d8-7f0104489999"},
+                 context()
+               )
+
+      assert message =~ "could not be found"
     end
   end
 
@@ -276,6 +390,85 @@ defmodule AshAi.ToolTest do
       tool_with_meta = Enum.find(tools, &(&1.name == :read_test_resources_with_meta))
 
       assert AshAi.Tool.has_meta?(tool_with_meta)
+    end
+  end
+
+  describe "get_by validation" do
+    test "rejects private lookup fields at compile time" do
+      domain =
+        Module.concat(__MODULE__, :"InvalidGetByDomain#{System.unique_integer([:positive])}")
+
+      resource =
+        Module.concat(__MODULE__, :"InvalidGetByResource#{System.unique_integer([:positive])}")
+
+      assert_raise Spark.Error.DslError, ~r/not public/, fn ->
+        Module.create(
+          resource,
+          quote do
+            use Ash.Resource,
+              domain: unquote(domain),
+              extensions: [AshAi],
+              data_layer: Ash.DataLayer.Ets,
+              validate_domain_inclusion?: false
+
+            attributes do
+              uuid_v7_primary_key(:id, writable?: true)
+              attribute(:private_name, :string)
+            end
+
+            actions do
+              defaults([:read])
+            end
+
+            tools do
+              tool(:get_by_private_name, :read, get_by: :private_name)
+            end
+          end,
+          Macro.Env.location(__ENV__)
+        )
+      end
+    end
+
+    test "rejects get_by on non-read tools at compile time" do
+      domain =
+        Module.concat(
+          __MODULE__,
+          :"InvalidGetByActionDomain#{System.unique_integer([:positive])}"
+        )
+
+      resource =
+        Module.concat(
+          __MODULE__,
+          :"InvalidGetByActionResource#{System.unique_integer([:positive])}"
+        )
+
+      assert_raise Spark.Error.DslError, ~r/only be used with read tools/, fn ->
+        Module.create(
+          resource,
+          quote do
+            use Ash.Resource,
+              domain: unquote(domain),
+              extensions: [AshAi],
+              data_layer: Ash.DataLayer.Ets,
+              validate_domain_inclusion?: false
+
+            attributes do
+              uuid_v7_primary_key(:id, writable?: true)
+              attribute(:name, :string, public?: true)
+            end
+
+            actions do
+              defaults([:read, :create])
+              default_accept([:name])
+            end
+
+            tools do
+              tool(:create_by_name, :create, get_by: :name)
+            end
+          end,
+          Macro.Env.location(__ENV__)
+        )
+      end
     end
   end
 


### PR DESCRIPTION
As per a brief discussion in
[discord](https://discord.com/channels/711271361523351632/1349578223515734037/1517133457677881465), this PR adds support for specifying a `get_by` argument on tool definitions. This will make it simpler to define e.g. a lookup tool that gets one record given its ID.

One old test assumed it was the only test resource in the ETS and caused
problems, which has been fixed by adding a filter.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
