### PR TITLE
Issue 165 Solution, adding placeholder pattern match for Attribute{}

### DIFF
--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -219,32 +219,7 @@ defmodule AshAi.Serializer do
         !field ->
           acc
 
-        match?(%Ash.Resource.Relationships.HasMany{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Relationships.HasOne{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Relationships.BelongsTo{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Relationships.ManyToMany{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Calculation{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Aggregate{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
-          acc
-
-        match?(%Ash.Resource.Attribute{}, field) &&
-            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
+        match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
           acc
 
         true ->

--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -243,6 +243,10 @@ defmodule AshAi.Serializer do
             match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
           acc
 
+        match?(%Ash.Resource.Attribute{}, field) &&
+            match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
+          acc
+
         true ->
           new_load =
             load

--- a/test/ash_ai/serializer_test.exs
+++ b/test/ash_ai/serializer_test.exs
@@ -42,15 +42,38 @@ defmodule AshAi.SerializerTest do
     end
   end
 
+  defmodule PartialSelectResource do
+    use Ash.Resource,
+      domain: AshAi.SerializerTest.TestDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :name, :string, public?: true
+      attribute :amount, :decimal, public?: true
+    end
+
+    actions do
+      defaults [:create]
+      default_accept [:name, :amount]
+
+      read :read_name_only do
+        prepare build(select: [:name])
+      end
+    end
+  end
+
   defmodule TestDomain do
     use Ash.Domain, extensions: [AshAi]
 
     resources do
       resource UnionResource
+      resource PartialSelectResource
     end
 
     tools do
       tool :read_union_resources, UnionResource, :read
+      tool :read_partial_select, PartialSelectResource, :read_name_only
     end
   end
 
@@ -77,6 +100,27 @@ defmodule AshAi.SerializerTest do
       assert item["data"]["type"] == "embedded"
       assert item["data"]["label"] == "hello"
       assert item["name"] == "test"
+    end
+  end
+
+  describe "Tools.execute with partial select" do
+    test "skips NotLoaded attributes when prepare build(select: ...) is used" do
+      PartialSelectResource
+      |> Ash.Changeset.for_create(:create, %{
+        name: "widget",
+        amount: Decimal.new("12.50")
+      })
+      |> Ash.create!()
+
+      [tool] =
+        AshAi.exposed_tools(actions: [{PartialSelectResource, [:read_name_only]}])
+
+      assert {:ok, json, _result} = AshAi.Tools.execute(tool, %{}, %{})
+
+      decoded = Jason.decode!(json)
+      [item] = decoded
+      assert item["name"] == "widget"
+      refute Map.has_key?(item, "amount")
     end
   end
 end


### PR DESCRIPTION
Fixes a crash when serializing records whose read action uses prepare build(select: [...]). Fields not in the select remain as %Ash.NotLoaded{} on the record; the serializer already skipped that for relationships, calculations, and aggregates, but not for plain attributes. That could crash during serialization (e.g. Decimal.to_string/2 on %Ash.NotLoaded{}).

This adds the same skip for %Ash.Resource.Attribute{} and a regression test that exercises the path through AshAi.Tools.execute/3.

Fixes #165.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
