### PR TITLE
chore: update to Elixir 1.20 and clean build suite

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.1.2
-elixir 1.18.4
+elixir 1.20
 pipx 1.8.0

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ When discovering tools with `AshAi.exposed_tools/1` and `actions: [{Resource, ..
 - tools defined on the domain for that resource
 - tools defined directly on the resource
 
-For migration guidance around `extra_tools`, `req_llm_opts`, and legacy adapter mapping, see [LangChain to ReqLLM Migration Guide](/documentation/topics/langchain-to-reqllm-migration.md).
+For migration guidance around `extra_tools`, `req_llm_opts`, and legacy adapter mapping, see [LangChain to ReqLLM Migration Guide](https://github.com/ash-project/ash_ai/blob/main/documentation/topics/langchain-to-reqllm-migration.md).
 
 ## Expose content as MCP resources
 
@@ -429,7 +429,7 @@ config :req_llm, google_api_key: System.fetch_env!("GOOGLE_API_KEY")
 
 For AshAi-specific model notes:
 - [Google Gemini 2.5](/documentation/models/gemini.md)
-- [LangChain to ReqLLM Migration Guide](/documentation/topics/langchain-to-reqllm-migration.md)
+- [LangChain to ReqLLM Migration Guide](https://github.com/ash-project/ash_ai/blob/main/documentation/topics/langchain-to-reqllm-migration.md)
 
 ## Vectorization
 

--- a/lib/ash_ai/tool_loop.ex
+++ b/lib/ash_ai/tool_loop.ex
@@ -542,7 +542,7 @@ defmodule AshAi.ToolLoop do
 
           merged_tool_calls =
             merge_tool_call_lists(
-              assistant.tool_calls || [],
+              assistant.tool_calls,
               normalize_context_tool_calls(tool_calls)
             )
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,13 @@ defmodule AshAi.MixProject do
       dialyzer: [plt_add_apps: [:ash, :mix]],
       description: @description,
       source_url: @source_url,
-      homepage_url: @source_url,
-      preferred_cli_env: [
+      homepage_url: @source_url
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         "test.create": :test,
         "test.migrate": :test,
         "test.rollback": :test,

--- a/priv/test_repo/migrations/20260610184522_run_codegen_extensions_1.exs
+++ b/priv/test_repo/migrations/20260610184522_run_codegen_extensions_1.exs
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule AshAi.TestRepo.Migrations.RunCodegenExtensions1 do
   @moduledoc """
   Installs any extensions that are mentioned in the repo's `installed_extensions/0` callback

--- a/test/support/embedding_model.ex
+++ b/test/support/embedding_model.ex
@@ -5,7 +5,6 @@
 defmodule AshAi.Test.EmbeddingModel do
   @moduledoc false
   use AshAi.EmbeddingModel
-  require Logger
 
   @impl true
   def dimensions(_opts), do: 1536

--- a/test/support/live_llm_case.ex
+++ b/test/support/live_llm_case.ex
@@ -99,12 +99,12 @@ defmodule AshAi.LiveLLMCase do
     quote do
       case unquote(provider) do
         :openai ->
-          unless AshAi.LiveLLMCase.openai_configured?() do
+          if !AshAi.LiveLLMCase.openai_configured?() do
             flunk("OPENAI_API_KEY environment variable not set - cannot run live LLM test")
           end
 
         :anthropic ->
-          unless AshAi.LiveLLMCase.anthropic_configured?() do
+          if !AshAi.LiveLLMCase.anthropic_configured?() do
             flunk("ANTHROPIC_API_KEY environment variable not set - cannot run live LLM test")
           end
       end


### PR DESCRIPTION
# Contributor checklist
Leave anything that you believe does not apply unchecked.

- [x]  I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ]  Bug fixes include regression tests
- [x]  Chores
- [ ]  Documentation changes
- [ ]  Features include unit/acceptance tests
- [ ]  Refactoring
- [ ]  Update dependencies

Part of issue: https://github.com/ash-project/ash/issues/2745

## Summary
- move Mix preferred CLI env configuration to the Elixir 1.20-compatible `cli/0` callback
- clean up compiler/type warnings surfaced while validating Elixir 1.20
- fix docs and REUSE metadata issues surfaced by `mix check`