### PR TITLE
fix: tolerate closed connection in MCP send_sse_event/4

### DIFF
--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -107,9 +107,11 @@ defmodule AshAi.Mcp.Server do
       "data: #{data}\n\n"
     ]
 
-    Enum.reduce(chunks, conn, fn chunk, conn ->
-      {:ok, conn} = Plug.Conn.chunk(conn, chunk)
-      conn
+    Enum.reduce_while(chunks, conn, fn chunk, conn ->
+      case Plug.Conn.chunk(conn, chunk) do
+        {:ok, conn} -> {:cont, conn}
+        {:error, _} -> {:halt, conn}
+      end
     end)
   end
 

--- a/test/ash_ai/mcp/rpc_test.exs
+++ b/test/ash_ai/mcp/rpc_test.exs
@@ -7,7 +7,15 @@ defmodule AshAi.Mcp.ServerTest do
   import Plug.{Conn, Test}
 
   alias AshAi.Mcp.Router
+  alias AshAi.Mcp.Server
   alias AshAi.Test.Music
+
+  defmodule ClosedAdapter do
+    @moduledoc false
+    # Minimal adapter that reports the connection as closed, mirroring what a
+    # real adapter returns from `chunk/2` when the SSE client has disconnected.
+    def chunk(_state, _body), do: {:error, :closed}
+  end
 
   @opts [tools: [:list_artists], otp_app: :ash_ai]
 
@@ -97,6 +105,25 @@ defmodule AshAi.Mcp.ServerTest do
       # Check that our test artist is in the results
       artists = Jason.decode!(text)
       assert Enum.any?(artists, fn a -> a["name"] == "Test Artist" end)
+    end
+  end
+
+  describe "send_sse_event/4" do
+    test "writes the event chunks to an open connection" do
+      conn =
+        conn(:get, "/")
+        |> send_chunked(200)
+        |> Server.send_sse_event("message", "hello", "1")
+
+      assert conn.resp_body =~ "id: 1\n"
+      assert conn.resp_body =~ "event: message\n"
+      assert conn.resp_body =~ "data: hello\n\n"
+    end
+
+    test "returns the conn without raising when the client has disconnected" do
+      conn = %{conn(:get, "/") | adapter: {ClosedAdapter, :closed}, state: :chunked}
+
+      assert %Plug.Conn{} = Server.send_sse_event(conn, "message", "hello", "1")
     end
   end
 end


### PR DESCRIPTION
Closes #213.

When an SSE client disconnects mid-stream, `Plug.Conn.chunk/2` returns `{:error, :closed}`, but `send_sse_event/4` hard-matched `{:ok, conn}` and raised a `MatchError`. A client going away is normal for a long-lived SSE connection, so this turns an expected condition into a crash (seen in production Sentry).

`keep_alive/1` in the same module already tolerates this by matching on the `chunk/2` result, so this brings the event path in line: it switches the `reduce` to `reduce_while` and stops chunking once the connection reports closed, returning the conn instead of raising.

Added a test for the disconnect path (via a small adapter that returns `{:error, :closed}`) plus one for the normal open-connection path.
