### PR TITLE
fix(mcp): harden current transport contract

### DIFF
--- a/lib/ash_ai/mcp/router.ex
+++ b/lib/ash_ai/mcp/router.ex
@@ -18,6 +18,11 @@ if Code.ensure_loaded?(Plug) do
     Tool schemas are generated without the OpenAI strict-mode transformation by
     default — MCP clients don't constrain sampling with the schema, so the
     honest form is smaller and clearer. Pass `strict: true` to restore it.
+
+    A `tool_argument_transformer` option may be a three-arity function receiving
+    the resolved `%AshAi.Tool{}`, its argument map, and the request's Ash tool
+    context. It must return `{:ok, arguments}` or `{:error, message}`. Rejections
+    are rendered as ordinary MCP tool errors in the selected protocol envelope.
     """
 
     use Plug.Router, copy_opts_to_assign: :router_opts

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -38,6 +38,7 @@ defmodule AshAi.Mcp.Server do
   @supported_protocol_versions @per_request_versions ++ @initialize_based_versions
 
   @meta_protocol_version "io.modelcontextprotocol/protocolVersion"
+  @meta_client_info "io.modelcontextprotocol/clientInfo"
   @meta_client_capabilities "io.modelcontextprotocol/clientCapabilities"
   @meta_server_info "io.modelcontextprotocol/serverInfo"
   @meta_subscription_id "io.modelcontextprotocol/subscriptionId"
@@ -138,7 +139,13 @@ defmodule AshAi.Mcp.Server do
     end
   end
 
-  # Batches are only defined for initialize-based protocol versions
+  # Batches are only defined for initialize-based protocol versions. A batch
+  # carrying a current/future per-request version must still enter the current
+  # handler so it can return one bounded Invalid Request response rather than
+  # accidentally using the initialize-era batch path.
+  defp per_request_version?(body, header_version) when is_list(body),
+    do: is_binary(header_version) and header_version >= hd(@per_request_versions)
+
   defp per_request_version?(_body, _header_version), do: false
 
   defp request_meta_version(%{"params" => %{"_meta" => %{@meta_protocol_version => version}}}),
@@ -177,6 +184,16 @@ defmodule AshAi.Mcp.Server do
     Plug.Conn.send_resp(conn, 202, "")
   end
 
+  defp handle_post_2026_07_28(conn, batch, _opts) when is_list(batch) do
+    error_response_2026_07_28(
+      conn,
+      400,
+      nil,
+      -32_600,
+      "JSON-RPC batch requests are not supported for protocol version 2026-07-28"
+    )
+  end
+
   defp handle_post_2026_07_28(conn, other, _opts) do
     error_response_2026_07_28(conn, 400, nil, -32_600, "Invalid Request Got: #{inspect(other)}")
   end
@@ -196,10 +213,20 @@ defmodule AshAi.Mcp.Server do
       not is_map(meta[@meta_client_capabilities]) ->
         "Invalid params: _meta is missing #{@meta_client_capabilities}"
 
+      Map.has_key?(meta, @meta_client_info) and
+          not valid_implementation?(meta[@meta_client_info]) ->
+        "Invalid params: #{@meta_client_info} must include string name and version fields"
+
       true ->
         nil
     end
   end
+
+  defp valid_implementation?(%{"name" => name, "version" => version})
+       when is_binary(name) and is_binary(version),
+       do: true
+
+  defp valid_implementation?(_client_info), do: false
 
   defp validate_headers_2026_07_28(conn, %{"method" => method} = message) do
     header_version = req_header(conn, "mcp-protocol-version")
@@ -207,6 +234,9 @@ defmodule AshAi.Mcp.Server do
     mcp_method = req_header(conn, "mcp-method")
 
     cond do
+      duplicate_req_header?(conn, "mcp-protocol-version") ->
+        "MCP-Protocol-Version header must appear exactly once"
+
       is_nil(header_version) ->
         "Missing required MCP-Protocol-Version header"
 
@@ -215,6 +245,9 @@ defmodule AshAi.Mcp.Server do
 
       is_nil(mcp_method) ->
         "Missing required Mcp-Method header"
+
+      duplicate_req_header?(conn, "mcp-method") ->
+        "Mcp-Method header must appear exactly once"
 
       mcp_method != method ->
         "Mcp-Method header value #{inspect(mcp_method)} does not match body value #{inspect(method)}"
@@ -234,11 +267,14 @@ defmodule AshAi.Mcp.Server do
         _ -> get_in(message, ["params", "name"])
       end
 
-    case req_header(conn, "mcp-name") do
-      nil ->
+    case {req_header(conn, "mcp-name"), duplicate_req_header?(conn, "mcp-name")} do
+      {_value, true} ->
+        "Mcp-Name header must appear exactly once"
+
+      {nil, false} ->
         "Missing required Mcp-Name header"
 
-      value ->
+      {value, false} ->
         case decode_header_value(value) do
           {:ok, ^expected} ->
             nil
@@ -437,6 +473,14 @@ defmodule AshAi.Mcp.Server do
     end
   end
 
+  defp duplicate_req_header?(conn, name) do
+    case Plug.Conn.get_req_header(conn, name) do
+      [_value] -> false
+      [] -> false
+      [_value | _duplicates] -> true
+    end
+  end
+
   defp trim_ows(value), do: String.replace(value, ~r/^[ \t]+|[ \t]+$/, "")
 
   @doc """
@@ -455,12 +499,15 @@ defmodule AshAi.Mcp.Server do
       [] ->
         :ok
 
-      [origin | _] ->
+      [origin] ->
         if origin_allowed?(trim_ows(origin), conn, opts[:allowed_origins]) do
           :ok
         else
           :forbidden
         end
+
+      [_origin | _duplicates] ->
+        :forbidden
     end
   end
 
@@ -507,12 +554,20 @@ defmodule AshAi.Mcp.Server do
   Handle HTTP DELETE request for session termination
   """
   def handle_delete(conn, session_id) do
-    if session_id do
-      conn
-      |> Plug.Conn.send_resp(200, "")
-    else
-      conn
-      |> Plug.Conn.send_resp(400, "")
+    case req_header(conn, "mcp-protocol-version") do
+      version when version in @per_request_versions ->
+        conn
+        |> Plug.Conn.put_resp_header("allow", "POST")
+        |> Plug.Conn.send_resp(405, "")
+
+      _initialize_based_or_absent ->
+        if session_id do
+          conn
+          |> Plug.Conn.send_resp(200, "")
+        else
+          conn
+          |> Plug.Conn.send_resp(400, "")
+        end
     end
   end
 
@@ -891,30 +946,67 @@ defmodule AshAi.Mcp.Server do
       %Tool{} = tool ->
         context = tool_context(opts)
 
-        case AshAi.Tools.execute(tool, tool_args, context) do
-          {:ok, result, _} ->
-            result = %{
-              "isError" => false,
-              "content" => [%{"type" => "text", "text" => result}]
-            }
-
-            if Tool.has_meta?(tool) do
-              {:ok, Map.put(result, "_meta", tool._meta)}
-            else
-              {:ok, result}
-            end
+        case transform_tool_arguments(tool, tool_args, context, opts) do
+          {:ok, transformed_args} ->
+            execute_resolved_tool(tool, transformed_args, context)
 
           {:error, error_text} ->
-            {:ok,
-             %{
-               "isError" => true,
-               "content" => [%{"type" => "text", "text" => error_text}]
-             }}
+            {:ok, tool_error_result(error_text)}
         end
 
       nil ->
         {:error, :tool_not_found}
     end
+  end
+
+  defp transform_tool_arguments(tool, arguments, context, opts) do
+    case opts[:tool_argument_transformer] do
+      nil ->
+        {:ok, arguments}
+
+      transformer when is_function(transformer, 3) ->
+        case transformer.(tool, arguments, context) do
+          {:ok, transformed_args} when is_map(transformed_args) ->
+            {:ok, transformed_args}
+
+          {:error, error_text} when is_binary(error_text) ->
+            {:error, error_text}
+
+          other ->
+            raise ArgumentError,
+                  "tool_argument_transformer must return {:ok, map} or {:error, string}, got: #{inspect(other)}"
+        end
+
+      other ->
+        raise ArgumentError,
+              "tool_argument_transformer must be a three-arity function, got: #{inspect(other)}"
+    end
+  end
+
+  defp execute_resolved_tool(tool, arguments, context) do
+    case AshAi.Tools.execute(tool, arguments, context) do
+      {:ok, result, _} ->
+        result = %{
+          "isError" => false,
+          "content" => [%{"type" => "text", "text" => result}]
+        }
+
+        if Tool.has_meta?(tool) do
+          {:ok, Map.put(result, "_meta", tool._meta)}
+        else
+          {:ok, result}
+        end
+
+      {:error, error_text} ->
+        {:ok, tool_error_result(error_text)}
+    end
+  end
+
+  defp tool_error_result(error_text) do
+    %{
+      "isError" => true,
+      "content" => [%{"type" => "text", "text" => error_text}]
+    }
   end
 
   defp read_resource_content(uri, params, session_id, opts) do

--- a/test/ash_ai/mcp/protocol_2026_07_28_test.exs
+++ b/test/ash_ai/mcp/protocol_2026_07_28_test.exs
@@ -125,6 +125,16 @@ defmodule AshAi.Mcp.Protocol20260728Test do
       assert response.status == 200
       assert Jason.decode!(response.resp_body)["result"]["resultType"] == "complete"
     end
+
+    test "a present but malformed clientInfo is rejected with -32602" do
+      for client_info <- [nil, "not-an-object", %{}, %{"name" => "client"}, %{"version" => "1"}] do
+        meta = Map.put(request_meta(), "io.modelcontextprotocol/clientInfo", client_info)
+        response = versioned_request("tools/list", %{"_meta" => meta})
+
+        assert response.status == 400
+        assert Jason.decode!(response.resp_body)["error"]["code"] == -32_602
+      end
+    end
   end
 
   describe "stateless requests" do
@@ -173,6 +183,29 @@ defmodule AshAi.Mcp.Protocol20260728Test do
 
       assert response.status == 200
       assert Jason.decode!(response.resp_body)["result"]["resultType"] == "complete"
+    end
+
+    test "tool argument transformer rejects after resolution in the current envelope" do
+      transformer = fn tool, arguments, context ->
+        assert %AshAi.Tool{name: :list_artists} = tool
+        assert arguments == %{"unexpected" => true}
+        assert is_map(context)
+        {:error, "Expected shape: {}"}
+      end
+
+      response =
+        versioned_request(
+          "tools/call",
+          %{"name" => "list_artists", "arguments" => %{"unexpected" => true}},
+          %{"mcp-name" => "list_artists"},
+          Keyword.put(@tool_opts, :tool_argument_transformer, transformer)
+        )
+
+      assert response.status == 200
+      result = Jason.decode!(response.resp_body)["result"]
+      assert result["resultType"] == "complete"
+      assert result["isError"] == true
+      assert result["content"] == [%{"type" => "text", "text" => "Expected shape: {}"}]
     end
 
     test "unknown tools return -32602" do
@@ -256,6 +289,45 @@ defmodule AshAi.Mcp.Protocol20260728Test do
 
       response = Router.call(conn, @tool_opts)
       assert response.status == 202
+    end
+
+    test "top-level JSON-RPC batches return one bounded Invalid Request error" do
+      conn =
+        conn(:post, "/", %{
+          "_json" => [
+            %{
+              "jsonrpc" => "2.0",
+              "id" => "batch_1",
+              "method" => "tools/list",
+              "params" => %{"_meta" => request_meta()}
+            }
+          ]
+        })
+        |> put_req_header("mcp-protocol-version", @protocol_version)
+
+      response = Router.call(conn, @tool_opts)
+      assert response.status == 400
+
+      assert %{
+               "jsonrpc" => "2.0",
+               "id" => nil,
+               "error" => %{
+                 "code" => -32_600,
+                 "message" =>
+                   "JSON-RPC batch requests are not supported for protocol version 2026-07-28"
+               }
+             } = Jason.decode!(response.resp_body)
+    end
+
+    test "DELETE is removed even when a session header is present" do
+      response =
+        conn(:delete, "/")
+        |> put_req_header("mcp-protocol-version", @protocol_version)
+        |> put_req_header("mcp-session-id", "initialize-era-session")
+        |> Router.call(@tool_opts)
+
+      assert response.status == 405
+      assert get_resp_header(response, "allow") == ["POST"]
     end
   end
 
@@ -395,6 +467,35 @@ defmodule AshAi.Mcp.Protocol20260728Test do
       assert get_resp_header(response, "mcp-session-id") == []
       assert Jason.decode!(response.resp_body)["result"]["resultType"] == "complete"
     end
+
+    test "conflicting duplicate routing headers are rejected" do
+      cases = [
+        {"mcp-protocol-version", "2099-01-01"},
+        {"mcp-method", "tools/call"}
+      ]
+
+      for {name, conflicting_value} <- cases do
+        response =
+          "tools/list"
+          |> versioned_conn("req_1", %{}, %{})
+          |> prepend_req_headers([{name, conflicting_value}])
+          |> Router.call(@tool_opts)
+
+        assert response.status == 400
+        assert Jason.decode!(response.resp_body)["error"]["code"] == -32_020
+      end
+
+      response =
+        "tools/call"
+        |> versioned_conn("req_1", %{"name" => "list_artists"}, %{
+          "mcp-name" => "list_artists"
+        })
+        |> prepend_req_headers([{"mcp-name", "another_tool"}])
+        |> Router.call(@tool_opts)
+
+      assert response.status == 400
+      assert Jason.decode!(response.resp_body)["error"]["code"] == -32_020
+    end
   end
 
   describe "origin validation" do
@@ -423,6 +524,17 @@ defmodule AshAi.Mcp.Protocol20260728Test do
         |> Router.call(Keyword.put(@tool_opts, :allowed_origins, ["https://app.example.com"]))
 
       assert response.status == 200
+    end
+
+    test "duplicate Origin headers are rejected even when one is allowed" do
+      response =
+        "tools/list"
+        |> versioned_conn("req_1", %{}, %{"origin" => "https://app.example.com"})
+        |> prepend_req_headers([{"origin", "https://app.example.com"}])
+        |> Router.call(Keyword.put(@tool_opts, :allowed_origins, ["https://app.example.com"]))
+
+      assert response.status == 403
+      assert Jason.decode!(response.resp_body)["error"]["message"] == "Origin not allowed"
     end
   end
 

--- a/test/ash_ai/mcp/rpc_test.exs
+++ b/test/ash_ai/mcp/rpc_test.exs
@@ -118,6 +118,18 @@ defmodule AshAi.Mcp.ServerTest do
     end
   end
 
+  describe "DELETE" do
+    test "initialize-era session termination remains supported" do
+      response =
+        conn(:delete, "/")
+        |> put_req_header("mcp-protocol-version", "2025-06-18")
+        |> put_req_header("mcp-session-id", "initialize-era-session")
+        |> Router.call(@opts)
+
+      assert response.status == 200
+    end
+  end
+
   describe "ping" do
     test "responds with an empty result" do
       conn = conn(:post, "/", %{method: "ping", id: "9"})
@@ -128,6 +140,33 @@ defmodule AshAi.Mcp.ServerTest do
       resp = Jason.decode!(response.resp_body)
       assert resp["id"] == "9"
       assert resp["result"] == %{}
+    end
+  end
+
+  describe "tool argument transformer" do
+    test "rejections use the initialize-era tool-result envelope" do
+      transformer = fn %AshAi.Tool{name: :list_artists}, arguments, _context ->
+        assert arguments == %{"unexpected" => true}
+        {:error, "Expected shape: {}"}
+      end
+
+      response =
+        conn(:post, "/", %{
+          "jsonrpc" => "2.0",
+          "id" => "transform_legacy",
+          "method" => "tools/call",
+          "params" => %{
+            "name" => "list_artists",
+            "arguments" => %{"unexpected" => true}
+          }
+        })
+        |> Router.call(Keyword.put(@opts, :tool_argument_transformer, transformer))
+
+      assert response.status == 200
+      result = Jason.decode!(response.resp_body)["result"]
+      refute Map.has_key?(result, "resultType")
+      assert result["isError"] == true
+      assert result["content"] == [%{"type" => "text", "text" => "Expected shape: {}"}]
     end
   end
 


### PR DESCRIPTION
## Summary\n\n- reject JSON-RPC batches on the MCP 2026-07-28 stateless path\n- return 405 for current-protocol DELETE regardless of session headers\n- reject duplicate Origin and MCP routing headers\n- validate a present per-request clientInfo object\n- add an optional post-resolution, pre-execution tool argument transformer so hosts can normalize or reject arguments without bypassing transport validation or runtime tool authorization\n\nInitialize-era batch, DELETE, and tool-result behavior remains unchanged when the new callback is not configured.\n\n## Validation\n\n- focused MCP suite: 45 tests, 0 failures\n- full suite: 301 tests, 0 failures, 28 excluded\n- mix format --check-formatted\n- mix credo --strict\n- git diff --check