### PR TITLE
fix(tools): serialize filtered aggregate results

### DIFF
--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -227,20 +227,25 @@ defmodule AshAi.Tool.Execution do
 
     aggregate_kind = String.to_existing_atom(aggregate_kind)
 
-    aggregate_struct =
-      Ash.Query.Aggregate.new!(resource, :aggregate_result, aggregate_kind, field: field.name)
+    {:ok, aggregate_type, aggregate_constraints} =
+      Ash.Query.Aggregate.kind_to_type(
+        aggregate_kind,
+        field.type,
+        field.constraints || []
+      )
 
     query
-    |> Ash.aggregate(aggregate_struct)
+    |> Ash.Query.unset([:limit, :offset])
+    |> Ash.aggregate({:aggregate_result, aggregate_kind, field: field.name})
     |> case do
-      {:ok, value} -> value
+      {:ok, %{aggregate_result: value}} -> value
       {:error, error} -> raise Ash.Error.to_error_class(error)
     end
     |> then(fn result ->
       result
       |> AshAi.Serializer.serialize_value(
-        aggregate_struct.type,
-        aggregate_struct.constraints,
+        aggregate_type,
+        aggregate_constraints,
         ctx.domain
       )
       |> Jason.encode!()

--- a/test/ash_ai/serializer_test.exs
+++ b/test/ash_ai/serializer_test.exs
@@ -63,17 +63,35 @@ defmodule AshAi.SerializerTest do
     end
   end
 
+  defmodule AggregateResource do
+    use Ash.Resource,
+      domain: AshAi.SerializerTest.TestDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :amount, :decimal, public?: true
+      attribute :category, :string, public?: true
+    end
+
+    actions do
+      defaults [:read, create: [:amount, :category]]
+    end
+  end
+
   defmodule TestDomain do
     use Ash.Domain, extensions: [AshAi]
 
     resources do
       resource UnionResource
       resource PartialSelectResource
+      resource AggregateResource
     end
 
     tools do
       tool :read_union_resources, UnionResource, :read
       tool :read_partial_select, PartialSelectResource, :read_name_only
+      tool :read_aggregate_resources, AggregateResource, :read
     end
   end
 
@@ -121,6 +139,49 @@ defmodule AshAi.SerializerTest do
       [item] = decoded
       assert item["name"] == "widget"
       refute Map.has_key?(item, "amount")
+    end
+  end
+
+  describe "Tools.execute with decimal aggregates" do
+    test "serializes the named aggregate result instead of the result map" do
+      for amount <- ["12.50", "7.25"] do
+        AggregateResource
+        |> Ash.Changeset.for_create(:create, %{
+          amount: Decimal.new(amount),
+          category: "included"
+        })
+        |> Ash.create!()
+      end
+
+      AggregateResource
+      |> Ash.Changeset.for_create(:create, %{
+        amount: Decimal.new("100.00"),
+        category: "excluded"
+      })
+      |> Ash.create!()
+
+      [tool] = AshAi.exposed_tools(actions: [{AggregateResource, [:read]}])
+
+      assert {:ok, json, _result} =
+               AshAi.Tools.execute(
+                 tool,
+                 %{
+                   "filter" => %{
+                     "field" => "category",
+                     "operator" => "eq",
+                     "value" => "included"
+                   },
+                   "limit" => 1,
+                   "offset" => 1,
+                   "result_type" => %{
+                     "aggregate" => "sum",
+                     "field" => "amount"
+                   }
+                 },
+                 %{}
+               )
+
+      assert Jason.decode!(json) == "19.75"
     end
   end
 end


### PR DESCRIPTION
## Summary

- preserve read filters when executing named aggregates
- remove record limit and offset before aggregation
- serialize the named scalar result with the aggregate output type

## Problem

Read tools built the aggregate as an `Ash.Query.Aggregate` struct. Ash does not apply the supplied query when that form is used, so filters could be ignored and the returned result map was serialized as if it were the scalar aggregate value.

The regression test covers a filtered decimal sum with limit and offset parameters.

## Tests

- `mix test test/ash_ai/tool_test.exs test/ash_ai/serializer_test.exs` (15 tests, 0 failures)