### PR TITLE
fix(tools): omit fields withheld by field policies

### DIFF
--- a/lib/ash_ai/serializer.ex
+++ b/lib/ash_ai/serializer.ex
@@ -222,6 +222,9 @@ defmodule AshAi.Serializer do
         match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
           acc
 
+        match?(%Ash.ForbiddenField{}, Map.get(record, field.name)) ->
+          acc
+
         true ->
           new_load =
             load

--- a/test/ash_ai/serializer_test.exs
+++ b/test/ash_ai/serializer_test.exs
@@ -79,6 +79,61 @@ defmodule AshAi.SerializerTest do
     end
   end
 
+  defmodule FieldPolicyResource do
+    use Ash.Resource,
+      domain: AshAi.SerializerTest.TestDomain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :name, :string, public?: true
+      attribute :secret, :string, public?: true
+    end
+
+    actions do
+      defaults [:read, create: [:name, :secret]]
+    end
+
+    policies do
+      policy always() do
+        authorize_if always()
+      end
+    end
+
+    field_policies do
+      field_policy :secret do
+        authorize_if actor_attribute_equals(:admin, true)
+      end
+
+      field_policy :* do
+        authorize_if always()
+      end
+    end
+  end
+
+  defmodule NestedFieldPolicyResource do
+    use Ash.Resource,
+      domain: AshAi.SerializerTest.TestDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_v7_primary_key(:id, writable?: true)
+      attribute :name, :string, public?: true
+    end
+
+    relationships do
+      belongs_to :user, AshAi.SerializerTest.FieldPolicyResource do
+        public? true
+        attribute_writable? true
+      end
+    end
+
+    actions do
+      defaults [:read, create: [:name, :user_id]]
+    end
+  end
+
   defmodule TestDomain do
     use Ash.Domain, extensions: [AshAi]
 
@@ -86,12 +141,16 @@ defmodule AshAi.SerializerTest do
       resource UnionResource
       resource PartialSelectResource
       resource AggregateResource
+      resource FieldPolicyResource
+      resource NestedFieldPolicyResource
     end
 
     tools do
       tool :read_union_resources, UnionResource, :read
       tool :read_partial_select, PartialSelectResource, :read_name_only
       tool :read_aggregate_resources, AggregateResource, :read
+      tool :read_field_policy_resources, FieldPolicyResource, :read
+      tool :read_nested_field_policy_resources, NestedFieldPolicyResource, :read, load: [:user]
     end
   end
 
@@ -140,6 +199,79 @@ defmodule AshAi.SerializerTest do
       assert item["name"] == "widget"
       refute Map.has_key?(item, "amount")
     end
+  end
+
+  describe "Tools.execute with field policies" do
+    setup context do
+      name = "widget-#{:erlang.phash2(context.test)}"
+
+      user =
+        FieldPolicyResource
+        |> Ash.Changeset.for_create(:create, %{name: name, secret: "hunter2"}, authorize?: false)
+        |> Ash.create!(authorize?: false)
+
+      NestedFieldPolicyResource
+      |> Ash.Changeset.for_create(:create, %{name: name, user_id: user.id})
+      |> Ash.create!()
+
+      [tool] = AshAi.exposed_tools(actions: [{FieldPolicyResource, [:read]}])
+      [nested_tool] = AshAi.exposed_tools(actions: [{NestedFieldPolicyResource, [:read]}])
+
+      {:ok, tool: tool, nested_tool: nested_tool, name: name}
+    end
+
+    test "omits fields the actor may not see instead of failing the call", %{
+      tool: tool,
+      name: name
+    } do
+      assert {:ok, json, _result} =
+               AshAi.Tools.execute(tool, %{}, %{actor: %{admin: false}})
+
+      item = fetch_by_name(json, name)
+      assert item["name"] == name
+      refute Map.has_key?(item, "secret")
+    end
+
+    test "still serializes the field for an actor who may see it", %{tool: tool, name: name} do
+      assert {:ok, json, _result} =
+               AshAi.Tools.execute(tool, %{}, %{actor: %{admin: true}})
+
+      assert fetch_by_name(json, name)["secret"] == "hunter2"
+    end
+
+    test "omits withheld fields on a loaded relationship", %{
+      nested_tool: nested_tool,
+      name: name
+    } do
+      assert {:ok, json, _result} =
+               AshAi.Tools.execute(nested_tool, %{}, %{actor: %{admin: false}})
+
+      user = fetch_user(json, name)
+      assert user["name"] == name
+      refute Map.has_key?(user, "secret")
+    end
+
+    test "still serializes a relationship field for an actor who may see it", %{
+      nested_tool: nested_tool,
+      name: name
+    } do
+      assert {:ok, json, _result} =
+               AshAi.Tools.execute(nested_tool, %{}, %{actor: %{admin: true}})
+
+      assert fetch_user(json, name)["secret"] == "hunter2"
+    end
+  end
+
+  defp fetch_by_name(json, name) do
+    json
+    |> Jason.decode!()
+    |> Enum.find(&(&1["name"] == name))
+  end
+
+  defp fetch_user(json, name) do
+    record = fetch_by_name(json, name)
+    refute is_nil(record), "no record named #{name} in #{json}"
+    record["user"]
   end
 
   describe "Tools.execute with decimal aggregates" do


### PR DESCRIPTION
## Problem

Any tool whose resource has a field policy fails outright — with `"unexpected error occurred"` — as soon as the acting user is not allowed to see one of the policied fields.

When a field policy withholds a value, Ash substitutes `%Ash.ForbiddenField{}`. `AshAi.Serializer.serialize_attributes/3` drops `%Ash.NotLoaded{}` (serializer.ex:222) but has no clause for the withheld case, so the struct reaches `Jason.encode!` in `Tools.execute`, which has no encoder for it, and the whole call fails.

The policy itself behaves correctly — Ash withheld the field exactly as configured. Only the serializer has no representation for the result.

The failure is unavoidable from the caller's side when the policied resource is reached through a relationship. `serialize_resource/3` (serializer.ex:82) hardcodes `fields: %{}`, so a nested resource is always serialized as *every* public attribute of its destination. Neither `load: [rel: [:some_field]]` nor an `Ash.Query.select` narrows it — the latter is re-enumerated as a load list and raises `Enumerable not implemented for Ash.Query`. A tool that loads a relationship to a resource carrying any field policy therefore has no way to avoid the crash short of not loading the relationship.

## Fix

Omit a withheld field for the same reason an unloaded one is omitted — there is no value to serialize:

```elixir
match?(%Ash.ForbiddenField{}, Map.get(record, field.name)) ->
  acc
```

`serialize_attributes/3` is the correct chokepoint: every record-shaped tool path in `lib/ash_ai/tool/execution.ex` — `execute_read/4` for the `"run_query"` kind, plus `run_create/5` and `run_update/6` — routes through `AshAi.Serializer.serialize_value/5` before `Jason.encode!`, and nested records recurse into the same `cond`. The remaining encode sites (`"count"`, `"exists"`, `"aggregate"`) serialize scalars and cannot receive a `ForbiddenField`.

This preserves the field policy's semantics. The field is absent for an actor who may not see it, present for one who may, and the tool call succeeds in both cases.

Omitting the key rather than emitting `null` is deliberate: it matches the existing `NotLoaded` handling and avoids disclosing the field's existence to an actor not authorized for it.

## Tests

Four tests in `test/ash_ai/serializer_test.exs`, alongside the existing `NotLoaded` one, over two new ETS-backed fixtures — `FieldPolicyResource` (a `:secret` attribute gated on `actor_attribute_equals(:admin, true)`) and `NestedFieldPolicyResource` (`belongs_to :user` pointing at it, exposed via `load: [:user]`).

Top-level:

- **omits fields the actor may not see instead of failing the call** — fails on `main` with exactly the reported `{:error, "unexpected error occurred"}`, passes with the fix.
- **still serializes the field for an actor who may see it** — passes both before and after, pinning the first test to the withheld case rather than to a broken fixture.

Through a relationship, covering the `serialize_resource/3` path described above:

- **omits withheld fields on a loaded relationship** — also fails on `main` with `Protocol.UndefinedError ... Jason.Encoder not implemented for Ash.ForbiddenField`.
- **still serializes a relationship field for an actor who may see it** — same control as the top-level pair.

Both `admin: false` tests were confirmed to fail with the fix reverted, so neither is vacuous.

Full suite: **306 tests, 0 failures**. `mix check` passes in full — compiler (`--warnings-as-errors`), formatter, `spark.formatter`, credo `--strict`, dialyzer (0 errors), sobelow, mix_audit, ex_doc, unused_deps, and reuse.

## Notes

Encountered while building an MCP tool over a resource whose `belongs_to :user` references a record with a field-policied API token. Exposing the user's `name` to the agent required loading the relationship, which pulled in the policied token attribute and failed the entire tool call.