### PR TITLE
fix(tools): reject a non-object tool `input` with an actionable error

### DIFF
--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -44,40 +44,42 @@ defmodule AshAi.Tool.Execution do
 
     opts = build_opts(domain, context)
 
-    resolved_load =
-      case load do
-        func when is_function(func, 1) -> func.(client_input)
-        list when is_list(list) -> list
-        _ -> []
+    with :ok <- validate_input_shape(client_input) do
+      resolved_load =
+        case load do
+          func when is_function(func, 1) -> func.(client_input)
+          list when is_list(list) -> list
+          _ -> []
+        end
+
+      exec_ctx = %Context{
+        actor: context[:actor],
+        tenant: context[:tenant],
+        context: context[:context] || %{},
+        load: resolved_load,
+        load_strict?: load_strict?,
+        select: select,
+        domain: domain
+      }
+
+      try do
+        validate_inputs!(resource, client_input, action, tool_arguments)
+        input = Map.take(client_input, valid_action_inputs(resource, action))
+
+        case action.type do
+          :read -> run_read(resource, action, arguments, input, opts, exec_ctx)
+          :create -> run_create(resource, action, input, opts, exec_ctx)
+          :update -> run_update(resource, action, arguments, input, opts, identity, exec_ctx)
+          :destroy -> run_destroy(resource, action, arguments, input, opts, identity, exec_ctx)
+          :action -> run_generic(resource, action, input, opts, exec_ctx)
+        end
+      rescue
+        error ->
+          {:error, Errors.format(error)}
+      catch
+        {:tool_error, error_msg} ->
+          {:error, error_msg}
       end
-
-    exec_ctx = %Context{
-      actor: context[:actor],
-      tenant: context[:tenant],
-      context: context[:context] || %{},
-      load: resolved_load,
-      load_strict?: load_strict?,
-      select: select,
-      domain: domain
-    }
-
-    try do
-      validate_inputs!(resource, client_input, action, tool_arguments)
-      input = Map.take(client_input, valid_action_inputs(resource, action))
-
-      case action.type do
-        :read -> run_read(resource, action, arguments, input, opts, exec_ctx)
-        :create -> run_create(resource, action, input, opts, exec_ctx)
-        :update -> run_update(resource, action, arguments, input, opts, identity, exec_ctx)
-        :destroy -> run_destroy(resource, action, arguments, input, opts, identity, exec_ctx)
-        :action -> run_generic(resource, action, input, opts, exec_ctx)
-      end
-    rescue
-      error ->
-        {:error, Errors.format(error)}
-    catch
-      {:tool_error, error_msg} ->
-        {:error, error_msg}
     end
   end
 
@@ -392,6 +394,14 @@ defmodule AshAi.Tool.Execution do
     end)
   end
 
+  defp validate_input_shape(client_input) when is_map(client_input), do: :ok
+
+  defp validate_input_shape(client_input) do
+    {:error,
+     "`input` must be a JSON object, got #{truncate(Jason.encode!(client_input))}. " <>
+       "Pass the arguments themselves, not a JSON-encoded string of them."}
+  end
+
   defp validate_inputs!(resource, client_input, action, tool_arguments) do
     allowed_keys =
       MapSet.new(
@@ -408,6 +418,10 @@ defmodule AshAi.Tool.Execution do
     else
       :ok
     end
+  end
+
+  defp truncate(encoded) do
+    if String.length(encoded) > 120, do: String.slice(encoded, 0, 120) <> "...", else: encoded
   end
 
   defp valid_action_inputs(resource, action) do

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -199,6 +199,31 @@ defmodule AshAi.ToolTest do
       {:ok, json, _raw} = registry["read_test_resources"].(nil, context())
       assert is_binary(json)
     end
+
+    test "rejects a non-object input naming the type that arrived" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(actions: [{TestResource, :*}], strict: false)
+
+      for input <- [~s({"public_name": "John"}), [1, 2], true, 42] do
+        {:error, error} = registry["read_test_resources"].(%{"input" => input}, context())
+
+        assert error =~ "`input` must be a JSON object"
+        assert error =~ "got #{Jason.encode!(input)}"
+        refute error =~ "unexpected error occurred"
+      end
+    end
+
+    test "truncates a long non-object input" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(actions: [{TestResource, :*}], strict: false)
+
+      {:error, error} =
+        registry["read_test_resources"].(%{"input" => String.duplicate("a", 500)}, context())
+
+      assert error =~ "`input` must be a JSON object"
+      assert error =~ "..."
+      assert String.length(error) < 300
+    end
   end
 
   describe "tool parameter schema visibility" do


### PR DESCRIPTION
Clients that JSON-encode `input` one time too many send a string where a map is expected. `Map.keys/1` then raised `BadMapError`, which surfaced as the opaque "unexpected error occurred" and told the caller nothing about what to send instead. Validate the shape up front and echo back what arrived.

The check runs before the `load` statement is resolved, so a `load` function is never handed a non-map input.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
