### PR TITLE
fix(tools): describe filter errors instead of "unexpected error occurred"

### DIFF
--- a/lib/ash_ai/to_tool_error.ex
+++ b/lib/ash_ai/to_tool_error.ex
@@ -88,6 +88,36 @@ defimpl AshAi.ToToolError, for: Ash.Error.Invalid.NoSuchInput do
   end
 end
 
+defimpl AshAi.ToToolError, for: Ash.Error.Query.NoSuchField do
+  def to_tool_error(error) do
+    "no such field: #{error.field}"
+  end
+end
+
+defimpl AshAi.ToToolError, for: Ash.Error.Query.NoSuchFilterPredicate do
+  def to_tool_error(error) do
+    "no such filter predicate: #{inspect(error.key)}"
+  end
+end
+
+defimpl AshAi.ToToolError, for: Ash.Error.Query.InvalidFilterValue do
+  def to_tool_error(%{value: value, message: message}) do
+    ["invalid filter value #{inspect(value)}", message]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(": ")
+  end
+end
+
+defimpl AshAi.ToToolError, for: Ash.Error.Query.InvalidFilterReference do
+  def to_tool_error(%{field: field, simple_equality?: true}) do
+    "#{field} cannot be referenced in filters, except by simple equality"
+  end
+
+  def to_tool_error(%{field: field}) do
+    "#{field} cannot be referenced in filters"
+  end
+end
+
 defimpl AshAi.ToToolError, for: Ash.Error.Invalid.InvalidPrimaryKey do
   def to_tool_error(_error) do
     "invalid primary key provided"

--- a/test/ash_ai/to_tool_error_test.exs
+++ b/test/ash_ai/to_tool_error_test.exs
@@ -170,6 +170,76 @@ defmodule AshAi.ToToolErrorTest do
     end
   end
 
+  describe "Ash.Error.Query.NoSuchField" do
+    test "names the field without leaking the resource module" do
+      error = Ash.Error.Query.NoSuchField.exception(field: :nickname, resource: Res)
+
+      assert AshAi.ToToolError.to_tool_error(error) == "no such field: nickname"
+    end
+  end
+
+  describe "Ash.Error.Query.NoSuchFilterPredicate" do
+    test "names the predicate without leaking the resource module" do
+      error =
+        Ash.Error.Query.NoSuchFilterPredicate.exception(key: "contains", resource: Res)
+
+      assert AshAi.ToToolError.to_tool_error(error) == "no such filter predicate: \"contains\""
+    end
+  end
+
+  describe "Ash.Error.Query.InvalidFilterValue" do
+    test "returns the value and message" do
+      error =
+        Ash.Error.Query.InvalidFilterValue.exception(
+          value: "abc",
+          message: "must be an integer"
+        )
+
+      assert AshAi.ToToolError.to_tool_error(error) ==
+               "invalid filter value \"abc\": must be an integer"
+    end
+
+    test "returns just the value when there is no message" do
+      error = Ash.Error.Query.InvalidFilterValue.exception(value: "abc")
+
+      assert AshAi.ToToolError.to_tool_error(error) == "invalid filter value \"abc\""
+    end
+
+    test "does not leak the internal filter context" do
+      error =
+        Ash.Error.Query.InvalidFilterValue.exception(
+          value: "abc",
+          context: %{resource: Res, public?: true, relationship_path: [:author]}
+        )
+
+      message = AshAi.ToToolError.to_tool_error(error)
+
+      assert message == "invalid filter value \"abc\""
+      refute message =~ "resource"
+      refute message =~ "relationship_path"
+    end
+  end
+
+  describe "Ash.Error.Query.InvalidFilterReference" do
+    test "explains that the field cannot be filtered on" do
+      error = Ash.Error.Query.InvalidFilterReference.exception(field: :full_name)
+
+      assert AshAi.ToToolError.to_tool_error(error) ==
+               "full_name cannot be referenced in filters"
+    end
+
+    test "notes when only simple equality is allowed" do
+      error =
+        Ash.Error.Query.InvalidFilterReference.exception(
+          field: :full_name,
+          simple_equality?: true
+        )
+
+      assert AshAi.ToToolError.to_tool_error(error) ==
+               "full_name cannot be referenced in filters, except by simple equality"
+    end
+  end
+
   describe "error class wrappers" do
     test "Ash.Error.Invalid returns class name" do
       error = Ash.Error.Invalid.exception(errors: [])


### PR DESCRIPTION
Four filter errors had no `AshAi.ToToolError` implementation, so a rejected filter rendered as the generic fallback and told the caller nothing about what to send instead.

The messages are written rather than relayed from `Exception.message/1`, which interpolates internals not meant for a tool caller: the filter builder's context (resource module, relationship path, visibility flags) for `InvalidFilterValue`, and the resource module for the two "no such" errors.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
