### PR TITLE
feat: add get_by argument to tool definitions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -21,6 +21,7 @@ spark_locals_without_parens = [
   full_filter_schema?: 1,
   full_text: 0,
   full_text: 1,
+  get_by: 1,
   html_path: 1,
   identity: 1,
   load: 1,

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Resources are exposed via the MCP server at `/mcp` and can be accessed by MCP-co
 
 **Important**: Tools have different access levels for different operations:
 - **Filtering/Sorting/Aggregation**: Only public attributes (`public?: true`) can be used
-- **Single-record lookup**: Use `get_by` on read tools to require public, filterable lookup fields and return one record
+- **Single-record lookup**: Use `get_by` on read tools to look up one record by filterable fields
 - **Arguments**: Only public action arguments are exposed
 - **Response data**: Public attributes are returned by default
 - **Loading data**: Use the `load` option to include relationships, calculations, or additional attributes (including private ones) in responses

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ defmodule MyApp.Blog do
 
   tools do
     tool :read_posts, MyApp.Blog.Post, :read
+    tool :get_post_by_id, MyApp.Blog.Post, :read, get_by: :id
     tool :create_post, MyApp.Blog.Post, :create
     tool :publish_post, MyApp.Blog.Post, :publish
     tool :read_comments, MyApp.Blog.Comment, :read
@@ -261,6 +262,7 @@ defmodule MyApp.Blog.Post do
 
   tools do
     tool :read_posts, :read
+    tool :get_post_by_slug, :read, get_by: :slug
     tool :create_post, :create
   end
 end
@@ -306,6 +308,7 @@ Resources are exposed via the MCP server at `/mcp` and can be accessed by MCP-co
 
 **Important**: Tools have different access levels for different operations:
 - **Filtering/Sorting/Aggregation**: Only public attributes (`public?: true`) can be used
+- **Single-record lookup**: Use `get_by` on read tools to require public, filterable lookup fields and return one record
 - **Arguments**: Only public action arguments are exposed
 - **Response data**: Public attributes are returned by default
 - **Loading data**: Use the `load` option to include relationships, calculations, or additional attributes (including private ones) in responses
@@ -315,7 +318,10 @@ Example:
 tools do
   # Returns only public attributes
   tool :read_posts, MyApp.Blog.Post, :read
-  
+
+  # Returns one post by ID instead of a list of results
+  tool :get_post_by_id, MyApp.Blog.Post, :read, get_by: :id
+
   # Returns public attributes AND loaded relationships/calculations
   # Note: loaded fields can include private attributes
   tool :read_posts_with_details, MyApp.Blog.Post, :read,

--- a/documentation/dsls/DSL-AshAi.md
+++ b/documentation/dsls/DSL-AshAi.md
@@ -40,6 +40,10 @@ tool :list_artists, Artist, :read
 ```
 
 ```
+tool :get_artist_by_id, Artist, :read, get_by: :id
+```
+
+```
 tool :create_artist, Artist, :create, description: "Create a new artist"
 ```
 
@@ -93,6 +97,7 @@ tool :list_artists, Artist, :read, ui: "ui://artists/list.html"
 | [`async`](#tools-tool-async){: #tools-tool-async } | `boolean` | `true` |  |
 | [`description`](#tools-tool-description){: #tools-tool-description } | `String.t` |  | A description for the tool. Defaults to the action's description. |
 | [`identity`](#tools-tool-identity){: #tools-tool-identity } | `atom` |  | The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely. |
+| [`get_by`](#tools-tool-get_by){: #tools-tool-get_by } | `atom \| list(atom)` |  | For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable. |
 | [`_meta`](#tools-tool-_meta){: #tools-tool-_meta } | `any` | `%{}` | Optional metadata map for tool integrations. Supports provider-specific extensions like OpenAI metadata. Keys and values should be strings to comply with JSON-RPC serialization. |
 | [`ui`](#tools-tool-ui){: #tools-tool-ui } | `atom \| String.t` |  | The `mcp_ui_resource` name (atom) or a `ui://` URI string for MCP Apps. Shortcut for setting `_meta.ui.resourceUri`. When an atom is given, the URI is resolved from the matching `mcp_ui_resource` declaration. |
 

--- a/documentation/dsls/DSL-AshAi.md
+++ b/documentation/dsls/DSL-AshAi.md
@@ -97,7 +97,7 @@ tool :list_artists, Artist, :read, ui: "ui://artists/list.html"
 | [`async`](#tools-tool-async){: #tools-tool-async } | `boolean` | `true` |  |
 | [`description`](#tools-tool-description){: #tools-tool-description } | `String.t` |  | A description for the tool. Defaults to the action's description. |
 | [`identity`](#tools-tool-identity){: #tools-tool-identity } | `atom` |  | The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely. |
-| [`get_by`](#tools-tool-get_by){: #tools-tool-get_by } | `atom \| list(atom)` |  | For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable. |
+| [`get_by`](#tools-tool-get_by){: #tools-tool-get_by } | `atom \| list(atom)` |  | For read actions, a field or list of fields used to fetch a single record. The fields must be filterable attributes, calculations or aggregates. |
 | [`_meta`](#tools-tool-_meta){: #tools-tool-_meta } | `any` | `%{}` | Optional metadata map for tool integrations. Supports provider-specific extensions like OpenAI metadata. Keys and values should be strings to comply with JSON-RPC serialization. |
 | [`ui`](#tools-tool-ui){: #tools-tool-ui } | `atom \| String.t` |  | The `mcp_ui_resource` name (atom) or a `ui://` URI string for MCP Apps. Shortcut for setting `_meta.ui.resourceUri`. When an atom is given, the URI is resolved from the matching `mcp_ui_resource` declaration. |
 

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -120,9 +120,6 @@ defmodule AshAi do
              ] ->
           {:error, "cannot `get_by` on the relationship `#{inspect(field_name)}`"}
 
-        %{public?: false} ->
-          {:error, "`#{inspect(field_name)}` is not public, so it cannot be used in `get_by`"}
-
         %{filterable?: false} ->
           {:error, "`#{inspect(field_name)}` is not filterable, so it cannot be used in `get_by`"}
 

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -34,6 +34,7 @@ defmodule AshAi do
       :async,
       :domain,
       :identity,
+      :get_by,
       :description,
       :action_parameters,
       :arguments,
@@ -89,6 +90,45 @@ defmodule AshAi do
 
         identity ->
           identity.keys
+      end
+    end
+
+    @doc """
+    Resolves the fields used to address a single record for read tools.
+    """
+    def get_by_fields(_resource, nil), do: []
+
+    def get_by_fields(resource, get_by) do
+      get_by
+      |> List.wrap()
+      |> Enum.map(fn field_name ->
+        field = Ash.Resource.Info.field(resource, field_name)
+
+        case validate_get_by_field(field, field_name, resource) do
+          :ok -> field
+          {:error, message} -> raise ArgumentError, message
+        end
+      end)
+    end
+
+    @doc """
+    Checks that a field resolved for `get_by` exists and is public and filterable.
+    """
+    def validate_get_by_field(nil, field_name, resource) do
+      {:error,
+       "`#{inspect(field_name)}` is not a valid attribute, calculation or aggregate on #{inspect(resource)}"}
+    end
+
+    def validate_get_by_field(field, field_name, _resource) do
+      cond do
+        !Map.get(field, :public?, false) ->
+          {:error, "`#{inspect(field_name)}` is not public, so it cannot be used in `get_by`"}
+
+        !Map.get(field, :filterable?, false) ->
+          {:error, "`#{inspect(field_name)}` is not filterable, so it cannot be used in `get_by`"}
+
+        true ->
+          :ok
       end
     end
   end

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -93,44 +93,52 @@ defmodule AshAi do
       end
     end
 
-    @doc """
-    Resolves the fields used to address a single record for read tools.
-    """
-    def get_by_fields(_resource, nil), do: []
-
+    @doc false
+    # Raises ArgumentError if a field is not usable as a lookup.
     def get_by_fields(resource, get_by) do
       get_by
       |> List.wrap()
       |> Enum.map(fn field_name ->
-        field = Ash.Resource.Info.field(resource, field_name)
-
-        case validate_get_by_field(field, field_name, resource) do
-          :ok -> field
+        case validate_get_by_field(resource, field_name) do
+          {:ok, field} -> field
           {:error, message} -> raise ArgumentError, message
         end
       end)
     end
 
-    @doc """
-    Checks that a field resolved for `get_by` exists and is public and filterable.
-    """
-    def validate_get_by_field(nil, field_name, resource) do
-      {:error,
-       "`#{inspect(field_name)}` is not a valid attribute, calculation or aggregate on #{inspect(resource)}"}
-    end
+    @doc false
+    # `resource` may be a resource module or its Spark.Dsl state, so this can run while the
+    # resource itself is being compiled.
+    def validate_get_by_field(resource, field_name) do
+      case Ash.Resource.Info.field(resource, field_name) do
+        %struct{}
+        when struct in [
+               Ash.Resource.Relationships.BelongsTo,
+               Ash.Resource.Relationships.HasOne,
+               Ash.Resource.Relationships.HasMany,
+               Ash.Resource.Relationships.ManyToMany
+             ] ->
+          {:error, "cannot `get_by` on the relationship `#{inspect(field_name)}`"}
 
-    def validate_get_by_field(field, field_name, _resource) do
-      cond do
-        !Map.get(field, :public?, false) ->
+        %{public?: false} ->
           {:error, "`#{inspect(field_name)}` is not public, so it cannot be used in `get_by`"}
 
-        !Map.get(field, :filterable?, false) ->
+        %{filterable?: false} ->
           {:error, "`#{inspect(field_name)}` is not filterable, so it cannot be used in `get_by`"}
 
-        true ->
-          :ok
+        nil ->
+          {:error,
+           "`#{inspect(field_name)}` is not a valid attribute, calculation or aggregate on #{inspect(resource_module(resource))}"}
+
+        field ->
+          {:ok, field}
       end
     end
+
+    defp resource_module(resource) when is_atom(resource), do: resource
+
+    defp resource_module(dsl_state),
+      do: Spark.Dsl.Transformer.get_persisted(dsl_state, :module, dsl_state)
   end
 
   defmodule McpResource do

--- a/lib/ash_ai/dsl.ex
+++ b/lib/ash_ai/dsl.ex
@@ -118,6 +118,11 @@ defmodule AshAi.Dsl do
       doc:
         "The identity to use for update/destroy actions. Defaults to the primary key. Set to `false` to disable entirely."
     ],
+    get_by: [
+      type: {:or, [:atom, {:list, :atom}]},
+      doc:
+        "For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable."
+    ],
     _meta: [
       type: :any,
       default: %{},
@@ -239,6 +244,7 @@ defmodule AshAi.Dsl do
     """,
     examples: [
       ~s(tool :list_artists, Artist, :read),
+      ~s(tool :get_artist_by_id, Artist, :read, get_by: :id),
       ~s(tool :create_artist, Artist, :create, description: "Create a new artist"),
       ~s(tool :update_artist, Artist, :update, identity: :id, load: [:albums]),
       ~s(tool :list_artists, Artist, :read, load: [albums: [:title]], load_strict?: true),

--- a/lib/ash_ai/dsl.ex
+++ b/lib/ash_ai/dsl.ex
@@ -121,7 +121,7 @@ defmodule AshAi.Dsl do
     get_by: [
       type: {:or, [:atom, {:list, :atom}]},
       doc:
-        "For read actions, a field or list of fields used to fetch a single record. The fields must be public and filterable."
+        "For read actions, a field or list of fields used to fetch a single record. The fields must be filterable attributes, calculations or aggregates."
     ],
     _meta: [
       type: :any,

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -34,6 +34,7 @@ defmodule AshAi.Tool.Execution do
           load_strict?: load_strict?,
           select: select,
           identity: identity,
+          get_by: get_by,
           arguments: tool_arguments
         },
         client_arguments,
@@ -67,7 +68,7 @@ defmodule AshAi.Tool.Execution do
         input = Map.take(client_input, valid_action_inputs(resource, action))
 
         case action.type do
-          :read -> run_read(resource, action, arguments, input, opts, exec_ctx)
+          :read -> run_read(resource, action, arguments, input, opts, get_by, exec_ctx)
           :create -> run_create(resource, action, input, opts, exec_ctx)
           :update -> run_update(resource, action, arguments, input, opts, identity, exec_ctx)
           :destroy -> run_destroy(resource, action, arguments, input, opts, identity, exec_ctx)
@@ -95,7 +96,7 @@ defmodule AshAi.Tool.Execution do
   defp serialize_opts(%Context{select: nil} = ctx), do: [load: ctx.load]
   defp serialize_opts(ctx), do: [load: ctx.load, select: ctx.select]
 
-  defp run_read(resource, action, arguments, input, opts, ctx) do
+  defp run_read(resource, action, arguments, input, opts, nil, ctx) do
     sort = build_sort(arguments["sort"])
     limit = build_limit(arguments["limit"], action.pagination)
 
@@ -109,6 +110,21 @@ defmodule AshAi.Tool.Execution do
       |> Ash.Query.for_read(action.name, input, opts)
 
     execute_read(query, action, arguments["result_type"] || "run_query", ctx)
+  end
+
+  defp run_read(resource, action, arguments, input, opts, get_by, ctx) do
+    resource
+    |> apply_select(ctx)
+    |> Ash.Query.for_read(action.name, input, opts)
+    |> Ash.Query.do_filter(get_by_filter(get_by, arguments))
+    |> Ash.read_one!(
+      Keyword.merge(opts,
+        load: ctx.load,
+        strict?: ctx.load_strict?,
+        not_found_error?: true
+      )
+    )
+    |> serialize_record(resource, ctx)
   end
 
   defp build_sort(sort) when is_list(sort) do
@@ -279,12 +295,7 @@ defmodule AshAi.Tool.Execution do
     |> Ash.Changeset.for_create(action.name, input, opts)
     |> apply_changeset_select(ctx)
     |> Ash.create!(load: ctx.load)
-    |> then(fn result ->
-      result
-      |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, serialize_opts(ctx))
-      |> Jason.encode!()
-      |> then(&{:ok, &1, result})
-    end)
+    |> serialize_record(resource, ctx)
   end
 
   defp run_update(resource, action, arguments, input, opts, identity, ctx) do
@@ -308,10 +319,7 @@ defmodule AshAi.Tool.Execution do
     )
     |> case do
       %Ash.BulkResult{status: :success, records: [result]} ->
-        result
-        |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, serialize_opts(ctx))
-        |> Jason.encode!()
-        |> then(&{:ok, &1, result})
+        serialize_record(result, resource, ctx)
 
       %Ash.BulkResult{status: :success, records: []} ->
         raise Ash.Error.to_error_class(Ash.Error.Query.NotFound.exception(primary_key: filter))
@@ -339,14 +347,18 @@ defmodule AshAi.Tool.Execution do
     )
     |> case do
       %Ash.BulkResult{status: :success, records: [result]} ->
-        result
-        |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, serialize_opts(ctx))
-        |> Jason.encode!()
-        |> then(&{:ok, &1, result})
+        serialize_record(result, resource, ctx)
 
       %Ash.BulkResult{status: :success, records: []} ->
         raise Ash.Error.to_error_class(Ash.Error.Query.NotFound.exception(primary_key: filter))
     end
+  end
+
+  defp serialize_record(result, resource, ctx) do
+    result
+    |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, serialize_opts(ctx))
+    |> Jason.encode!()
+    |> then(&{:ok, &1, result})
   end
 
   defp run_generic(resource, action, input, opts, ctx) do
@@ -391,6 +403,19 @@ defmodule AshAi.Tool.Execution do
     |> AshAi.Tool.identity_keys(identity)
     |> Enum.map(fn key ->
       {key, Map.get(arguments, to_string(key))}
+    end)
+  end
+
+  # The get_by fields were already validated at compile time and schema build,
+  # so only their names are needed here.
+  defp get_by_filter(get_by, arguments) do
+    get_by
+    |> List.wrap()
+    |> Map.new(fn field_name ->
+      case Map.get(arguments, to_string(field_name)) do
+        nil -> throw({:tool_error, "Missing required get_by argument: #{field_name}"})
+        value -> {field_name, value}
+      end
     end)
   end
 

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -116,7 +116,7 @@ defmodule AshAi.Tool.Execution do
     resource
     |> apply_select(ctx)
     |> Ash.Query.for_read(action.name, input, opts)
-    |> Ash.Query.do_filter(get_by_filter(get_by, arguments))
+    |> Ash.Query.do_filter(get_by_filter(resource, get_by, arguments))
     |> Ash.read_one!(
       Keyword.merge(opts,
         load: ctx.load,
@@ -406,17 +406,43 @@ defmodule AshAi.Tool.Execution do
     end)
   end
 
-  # The get_by fields were already validated at compile time and schema build,
-  # so only their names are needed here.
-  defp get_by_filter(get_by, arguments) do
+  defp get_by_filter(resource, get_by, arguments) do
     get_by
     |> List.wrap()
     |> Map.new(fn field_name ->
       case Map.get(arguments, to_string(field_name)) do
         nil -> throw({:tool_error, "Missing required get_by argument: #{field_name}"})
-        value -> {field_name, value}
+        value -> {field_name, cast_get_by_value!(resource, field_name, value)}
       end
     end)
+  end
+
+  # Values arrive as JSON primitives, so they are cast to the field's type before
+  # filtering. Mirrors what `Ash.CodeInterface` does for `get_by` code interfaces.
+  defp cast_get_by_value!(resource, field_name, value) do
+    {type, constraints} = get_by_field_type(resource, field_name)
+
+    with {:ok, casted} <- Ash.Type.cast_input(type, value, constraints),
+         {:ok, casted} <- Ash.Type.apply_constraints(type, casted, constraints) do
+      casted
+    else
+      _ ->
+        throw(
+          {:tool_error,
+           "Invalid value for get_by argument #{field_name}: #{truncate(Jason.encode!(value))}"}
+        )
+    end
+  end
+
+  defp get_by_field_type(resource, field_name) do
+    case Ash.Resource.Info.field(resource, field_name) do
+      %Ash.Resource.Aggregate{} = aggregate ->
+        {:ok, type, constraints} = Ash.Query.Aggregate.aggregate_type(resource, aggregate)
+        {type, constraints}
+
+      %{type: type} = field ->
+        {type, Map.get(field, :constraints) || []}
+    end
   end
 
   defp validate_input_shape(client_input) when is_map(client_input), do: :ok

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -388,7 +388,7 @@ defmodule AshAi.Tool.Execution do
     resource
     |> AshAi.Tool.identity_keys(nil)
     |> Enum.reduce(nil, fn key, expr ->
-      value = Map.get(arguments, to_string(key))
+      value = identity_value(resource, key, arguments)
 
       if expr do
         Ash.Expr.expr(^expr and ^Ash.Expr.ref(key) == ^value)
@@ -402,8 +402,14 @@ defmodule AshAi.Tool.Execution do
     resource
     |> AshAi.Tool.identity_keys(identity)
     |> Enum.map(fn key ->
-      {key, Map.get(arguments, to_string(key))}
+      {key, identity_value(resource, key, arguments)}
     end)
+  end
+
+  defp identity_value(resource, key, arguments) do
+    arguments
+    |> Map.get(to_string(key))
+    |> then(&cast_lookup_value!(resource, key, &1, "identity"))
   end
 
   defp get_by_filter(resource, get_by, arguments) do
@@ -412,15 +418,18 @@ defmodule AshAi.Tool.Execution do
     |> Map.new(fn field_name ->
       case Map.get(arguments, to_string(field_name)) do
         nil -> throw({:tool_error, "Missing required get_by argument: #{field_name}"})
-        value -> {field_name, cast_get_by_value!(resource, field_name, value)}
+        value -> {field_name, cast_lookup_value!(resource, field_name, value, "get_by")}
       end
     end)
   end
 
   # Values arrive as JSON primitives, so they are cast to the field's type before
   # filtering. Mirrors what `Ash.CodeInterface` does for `get_by` code interfaces.
-  defp cast_get_by_value!(resource, field_name, value) do
-    {type, constraints} = get_by_field_type(resource, field_name)
+  # A missing argument stays `nil` here, so the caller decides how to handle it.
+  defp cast_lookup_value!(_resource, _field_name, nil, _label), do: nil
+
+  defp cast_lookup_value!(resource, field_name, value, label) do
+    {type, constraints} = lookup_field_type(resource, field_name)
 
     with {:ok, casted} <- Ash.Type.cast_input(type, value, constraints),
          {:ok, casted} <- Ash.Type.apply_constraints(type, casted, constraints) do
@@ -429,12 +438,12 @@ defmodule AshAi.Tool.Execution do
       _ ->
         throw(
           {:tool_error,
-           "Invalid value for get_by argument #{field_name}: #{truncate(Jason.encode!(value))}"}
+           "Invalid value for #{label} argument #{field_name}: #{truncate(Jason.encode!(value))}"}
         )
     end
   end
 
-  defp get_by_field_type(resource, field_name) do
+  defp lookup_field_type(resource, field_name) do
     case Ash.Resource.Info.field(resource, field_name) do
       %Ash.Resource.Aggregate{} = aggregate ->
         {:ok, type, constraints} = Ash.Query.Aggregate.aggregate_type(resource, aggregate)

--- a/lib/ash_ai/tool/schema.ex
+++ b/lib/ash_ai/tool/schema.ex
@@ -52,8 +52,10 @@ defmodule AshAi.Tool.Schema do
     get_by = Keyword.get(opts, :get_by, nil)
 
     get_by_fields =
-      if get_by && action.type == :read do
+      if action.type == :read do
         AshAi.Tool.get_by_fields(resource, get_by)
+      else
+        []
       end
 
     attributes =
@@ -132,7 +134,7 @@ defmodule AshAi.Tool.Schema do
           get_by_fields: get_by_fields,
           full_filter_schema?: Keyword.get(opts, :full_filter_schema?, false)
         ),
-      required: Map.keys(props_with_input) ++ Enum.map(get_by_fields || [], & &1.name),
+      required: Map.keys(props_with_input) ++ Enum.map(get_by_fields, & &1.name),
       additionalProperties: false
     }
     |> Jason.encode!()
@@ -255,8 +257,15 @@ defmodule AshAi.Tool.Schema do
          action_parameters,
          opts
        ) do
-    case Keyword.get(opts, :get_by_fields) do
-      nil ->
+    case Keyword.get(opts, :get_by_fields, []) do
+      [_ | _] = get_by_fields ->
+        get_by_fields
+        |> Map.new(fn field ->
+          {field.name, AshAi.OpenApi.resource_write_attribute_type(field, resource, :create)}
+        end)
+        |> then(&Map.merge(properties, &1))
+
+      [] ->
         strict? = Keyword.get(opts, :strict?, true)
         {allowed_result_types, action_parameters} = extract_result_types(action_parameters)
 
@@ -269,14 +278,6 @@ defmodule AshAi.Tool.Schema do
           allowed_result_types,
           opts
         )
-
-      get_by_fields ->
-        get_by_properties =
-          Map.new(get_by_fields, fn field ->
-            {field.name, AshAi.OpenApi.resource_write_attribute_type(field, resource, :create)}
-          end)
-
-        Map.merge(properties, get_by_properties)
     end
   end
 

--- a/lib/ash_ai/tool/schema.ex
+++ b/lib/ash_ai/tool/schema.ex
@@ -21,7 +21,8 @@ defmodule AshAi.Tool.Schema do
           action: action,
           action_parameters: action_parameters,
           arguments: tool_arguments,
-          identity: identity
+          identity: identity,
+          get_by: get_by
         } = tool,
         opts \\ []
       ) do
@@ -30,6 +31,7 @@ defmodule AshAi.Tool.Schema do
     for_action(domain, resource, action, action_parameters, tool_arguments,
       strict?: strict?,
       identity: identity,
+      get_by: get_by,
       full_filter_schema?: Map.get(tool, :full_filter_schema?, false)
     )
   end
@@ -47,6 +49,12 @@ defmodule AshAi.Tool.Schema do
       ) do
     strict? = Keyword.get(opts, :strict?, true)
     identity = Keyword.get(opts, :identity, nil)
+    get_by = Keyword.get(opts, :get_by, nil)
+
+    get_by_fields =
+      if get_by && action.type == :read do
+        AshAi.Tool.get_by_fields(resource, get_by)
+      end
 
     attributes =
       if action.type in [:action, :read] do
@@ -121,9 +129,10 @@ defmodule AshAi.Tool.Schema do
         add_action_specific_properties(props_with_input, resource, action, action_parameters,
           strict?: strict?,
           identity: identity,
+          get_by_fields: get_by_fields,
           full_filter_schema?: Keyword.get(opts, :full_filter_schema?, false)
         ),
-      required: Map.keys(props_with_input),
+      required: Map.keys(props_with_input) ++ Enum.map(get_by_fields || [], & &1.name),
       additionalProperties: false
     }
     |> Jason.encode!()
@@ -246,9 +255,69 @@ defmodule AshAi.Tool.Schema do
          action_parameters,
          opts
        ) do
-    strict? = Keyword.get(opts, :strict?, true)
-    {allowed_result_types, action_parameters} = extract_result_types(action_parameters)
+    case Keyword.get(opts, :get_by_fields) do
+      nil ->
+        strict? = Keyword.get(opts, :strict?, true)
+        {allowed_result_types, action_parameters} = extract_result_types(action_parameters)
 
+        read_query_properties(
+          properties,
+          resource,
+          pagination,
+          action_parameters,
+          strict?,
+          allowed_result_types,
+          opts
+        )
+
+      get_by_fields ->
+        get_by_properties =
+          Map.new(get_by_fields, fn field ->
+            {field.name, AshAi.OpenApi.resource_write_attribute_type(field, resource, :create)}
+          end)
+
+        Map.merge(properties, get_by_properties)
+    end
+  end
+
+  defp add_action_specific_properties(
+         properties,
+         resource,
+         %{type: type},
+         _action_parameters,
+         opts
+       )
+       when type in [:update, :destroy] do
+    identity = Keyword.get(opts, :identity, nil)
+
+    # Mirror `AshAi.Tool.Execution.identity_filter/3`: address records by the
+    # configured identity (or the primary key by default, or nothing when `false`).
+    identity_properties =
+      resource
+      |> AshAi.Tool.identity_keys(identity)
+      |> Map.new(fn key ->
+        value =
+          Ash.Resource.Info.attribute(resource, key)
+          |> AshAi.OpenApi.resource_write_attribute_type(resource, type)
+
+        {key, value}
+      end)
+
+    Map.merge(properties, identity_properties)
+  end
+
+  defp add_action_specific_properties(properties, _resource, _action, _action_parameters, _opts),
+    do: properties
+
+  defp read_query_properties(
+         properties,
+         resource,
+         pagination,
+         action_parameters,
+         strict?,
+         allowed_result_types,
+         opts
+       ) do
     aggregate_fields =
       Ash.Resource.Info.fields(resource, [
         :attributes,
@@ -488,35 +557,6 @@ defmodule AshAi.Tool.Schema do
       end
     end)
   end
-
-  defp add_action_specific_properties(
-         properties,
-         resource,
-         %{type: type},
-         _action_parameters,
-         opts
-       )
-       when type in [:update, :destroy] do
-    identity = Keyword.get(opts, :identity, nil)
-
-    # Mirror `AshAi.Tool.Execution.identity_filter/3`: address records by the
-    # configured identity (or the primary key by default, or nothing when `false`).
-    identity_properties =
-      resource
-      |> AshAi.Tool.identity_keys(identity)
-      |> Map.new(fn key ->
-        value =
-          Ash.Resource.Info.attribute(resource, key)
-          |> AshAi.OpenApi.resource_write_attribute_type(resource, type)
-
-        {key, value}
-      end)
-
-    Map.merge(properties, identity_properties)
-  end
-
-  defp add_action_specific_properties(properties, _resource, _action, _action_parameters, _opts),
-    do: properties
 
   defp add_input_for_fields(sort_obj, resource) do
     resource

--- a/lib/ash_ai/transformers/resource_tools.ex
+++ b/lib/ash_ai/transformers/resource_tools.ex
@@ -50,7 +50,81 @@ defmodule AshAi.Transformers.ResourceTools do
           dsl
       end
     end)
+    |> validate_tools!(module, resource_dsl?)
     |> then(&{:ok, &1})
+  end
+
+  defp validate_tools!(dsl_state, module, resource_dsl?) do
+    dsl_state
+    |> Transformer.get_entities([:tools])
+    |> Enum.each(&validate_get_by!(&1, dsl_state, module, resource_dsl?))
+
+    dsl_state
+  end
+
+  defp validate_get_by!(%{get_by: nil}, _dsl_state, _module, _resource_dsl?), do: :ok
+
+  defp validate_get_by!(tool, dsl_state, module, resource_dsl?) do
+    case fetch_action(tool, dsl_state, resource_dsl?) do
+      :deferred ->
+        :ok
+
+      nil ->
+        raise Spark.Error.DslError,
+          module: module,
+          path: [:tools, tool.name, :action],
+          message:
+            "Tool `#{tool.name}` references action `#{tool.action}`, but no such action exists."
+
+      %{type: :read} ->
+        validate_get_by_fields!(tool, dsl_state, module, resource_dsl?)
+
+      _action ->
+        raise_get_by_error!(tool, module, "`get_by` can only be used with read tools.")
+    end
+  end
+
+  # Resource-level tools point at the module being compiled, so its own
+  # dsl_state is the source of truth (this transformer runs after Ash has
+  # materialized default actions). Domain-level tools reference other modules,
+  # which may not be compiled yet — those are skipped here and the same checks
+  # run again when the tool's schema is built.
+  defp fetch_action(tool, dsl_state, true) do
+    Ash.Resource.Info.action(dsl_state, tool.action)
+  end
+
+  defp fetch_action(tool, _dsl_state, false) do
+    case Code.ensure_loaded(tool.resource) do
+      {:module, resource} ->
+        if Ash.Resource.Info.resource?(resource) do
+          Ash.Resource.Info.action(resource, tool.action)
+        end
+
+      {:error, _reason} ->
+        :deferred
+    end
+  end
+
+  defp validate_get_by_fields!(tool, dsl_state, module, resource_dsl?) do
+    source = if resource_dsl?, do: dsl_state, else: tool.resource
+
+    tool.get_by
+    |> List.wrap()
+    |> Enum.each(fn field_name ->
+      field = Ash.Resource.Info.field(source, field_name)
+
+      case AshAi.Tool.validate_get_by_field(field, field_name, tool.resource) do
+        :ok -> :ok
+        {:error, message} -> raise_get_by_error!(tool, module, message)
+      end
+    end)
+  end
+
+  defp raise_get_by_error!(tool, module, message) do
+    raise Spark.Error.DslError,
+      module: module,
+      path: [:tools, tool.name, :get_by],
+      message: message
   end
 
   defp resource_dsl?(module) do

--- a/lib/ash_ai/transformers/resource_tools.ex
+++ b/lib/ash_ai/transformers/resource_tools.ex
@@ -84,11 +84,8 @@ defmodule AshAi.Transformers.ResourceTools do
     end
   end
 
-  # Resource-level tools point at the module being compiled, so its own
-  # dsl_state is the source of truth (this transformer runs after Ash has
-  # materialized default actions). Domain-level tools reference other modules,
-  # which may not be compiled yet — those are skipped here and the same checks
-  # run again when the tool's schema is built.
+  # Domain-level tools reference other modules, which may not be compiled yet. Those are
+  # skipped here; the same checks run again when the tool's schema is built.
   defp fetch_action(tool, dsl_state, true) do
     Ash.Resource.Info.action(dsl_state, tool.action)
   end
@@ -111,10 +108,8 @@ defmodule AshAi.Transformers.ResourceTools do
     tool.get_by
     |> List.wrap()
     |> Enum.each(fn field_name ->
-      field = Ash.Resource.Info.field(source, field_name)
-
-      case AshAi.Tool.validate_get_by_field(field, field_name, tool.resource) do
-        :ok -> :ok
+      case AshAi.Tool.validate_get_by_field(source, field_name) do
+        {:ok, _field} -> :ok
         {:error, message} -> raise_get_by_error!(tool, module, message)
       end
     end)

--- a/test/ash_ai/resource_tools_test.exs
+++ b/test/ash_ai/resource_tools_test.exs
@@ -155,18 +155,9 @@ defmodule AshAi.ResourceToolsTest do
       end
     end
 
-    test "domain-level get_by tools tolerate resources compiled later" do
-      domain =
-        Module.concat(
-          __MODULE__,
-          :"DeferredGetByDomain#{System.unique_integer([:positive])}"
-        )
-
-      resource =
-        Module.concat(
-          __MODULE__,
-          :"DeferredGetByResource#{System.unique_integer([:positive])}"
-        )
+    test "domain-level get_by tools tolerate resources compiled later", %{test: test} do
+      domain = Module.concat([__MODULE__, test, Domain])
+      resource = Module.concat([__MODULE__, test, Resource])
 
       assert {:module, ^domain, _binary, _term} =
                Module.create(

--- a/test/ash_ai/resource_tools_test.exs
+++ b/test/ash_ai/resource_tools_test.exs
@@ -31,6 +31,7 @@ defmodule AshAi.ResourceToolsTest do
 
     tools do
       tool(:resource_read, :read)
+      tool(:resource_get_by_id, :read, get_by: :id)
       tool(:resource_create, :create)
     end
   end
@@ -91,6 +92,17 @@ defmodule AshAi.ResourceToolsTest do
       assert tool.action == :read
     end
 
+    test "tool :name, :action supports get_by" do
+      tool =
+        ResourceToolResource
+        |> AshAi.Info.tools()
+        |> Enum.find(&(&1.name == :resource_get_by_id))
+
+      assert tool.resource == ResourceToolResource
+      assert tool.action == :read
+      assert tool.get_by == :id
+    end
+
     test "resource-level tools reject explicit resource argument" do
       module =
         Module.concat(__MODULE__, :"InvalidResourceTool#{System.unique_integer([:positive])}")
@@ -142,6 +154,67 @@ defmodule AshAi.ResourceToolsTest do
         )
       end
     end
+
+    test "domain-level get_by tools tolerate resources compiled later" do
+      domain =
+        Module.concat(
+          __MODULE__,
+          :"DeferredGetByDomain#{System.unique_integer([:positive])}"
+        )
+
+      resource =
+        Module.concat(
+          __MODULE__,
+          :"DeferredGetByResource#{System.unique_integer([:positive])}"
+        )
+
+      assert {:module, ^domain, _binary, _term} =
+               Module.create(
+                 domain,
+                 quote do
+                   use Ash.Domain, extensions: [AshAi], validate_config_inclusion?: false
+
+                   resources do
+                     resource unquote(resource)
+                   end
+
+                   tools do
+                     tool(:get_deferred_resource, unquote(resource), :read, get_by: :id)
+                   end
+                 end,
+                 Macro.Env.location(__ENV__)
+               )
+
+      assert {:module, ^resource, _binary, _term} =
+               Module.create(
+                 resource,
+                 quote do
+                   use Ash.Resource,
+                     domain: unquote(domain),
+                     extensions: [AshAi],
+                     data_layer: Ash.DataLayer.Ets,
+                     validate_domain_inclusion?: false
+
+                   attributes do
+                     uuid_v7_primary_key(:id, writable?: true)
+                   end
+
+                   actions do
+                     defaults([:read])
+                   end
+                 end,
+                 Macro.Env.location(__ENV__)
+               )
+
+      tool =
+        domain
+        |> AshAi.Info.tools()
+        |> Enum.find(&(&1.name == :get_deferred_resource))
+
+      assert tool.resource == resource
+      assert tool.action == :read
+      assert tool.get_by == :id
+    end
   end
 
   describe "AshAi.exposed_tools/1 discovery" do
@@ -151,7 +224,12 @@ defmodule AshAi.ResourceToolsTest do
       assert tools
              |> Enum.map(& &1.name)
              |> MapSet.new() ==
-               MapSet.new([:resource_read, :resource_create, :domain_create_alias])
+               MapSet.new([
+                 :resource_read,
+                 :resource_get_by_id,
+                 :resource_create,
+                 :domain_create_alias
+               ])
     end
 
     test "actions filter by specific action keeps matching tools from both levels" do

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -322,6 +322,37 @@ defmodule AshAi.ToolTest do
                registry["get_test_resource_by_id"].(%{}, context())
     end
 
+    test "casts lookup values to the field type", %{resource: resource} do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:ok, _json, fetched} =
+               registry["get_test_resource_by_id"].(
+                 %{"id" => String.upcase(resource.id)},
+                 context()
+               )
+
+      assert fetched.id == resource.id
+    end
+
+    test "returns a tool error when a lookup value is not castable" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:error, message} =
+               registry["get_test_resource_by_id"].(%{"id" => "not-a-uuid"}, context())
+
+      assert message =~ "Invalid value for get_by argument id"
+    end
+
     test "returns a tool error when no record matches" do
       {_tools, registry} =
         AshAi.build_tools_and_registry(
@@ -419,12 +450,9 @@ defmodule AshAi.ToolTest do
   end
 
   describe "get_by validation" do
-    test "rejects private lookup fields at compile time" do
-      domain =
-        Module.concat(__MODULE__, :"InvalidGetByDomain#{System.unique_integer([:positive])}")
-
-      resource =
-        Module.concat(__MODULE__, :"InvalidGetByResource#{System.unique_integer([:positive])}")
+    test "rejects private lookup fields at compile time", %{test: test} do
+      domain = Module.concat([__MODULE__, test, Domain])
+      resource = Module.concat([__MODULE__, test, Resource])
 
       assert_raise Spark.Error.DslError, ~r/not public/, fn ->
         Module.create(
@@ -454,18 +482,68 @@ defmodule AshAi.ToolTest do
       end
     end
 
-    test "rejects get_by on non-read tools at compile time" do
-      domain =
-        Module.concat(
-          __MODULE__,
-          :"InvalidGetByActionDomain#{System.unique_integer([:positive])}"
-        )
+    test "rejects relationship lookup fields at compile time", %{test: test} do
+      domain = Module.concat([__MODULE__, test, Domain])
+      resource = Module.concat([__MODULE__, test, Resource])
+      related = Module.concat([__MODULE__, test, Related])
 
-      resource =
-        Module.concat(
-          __MODULE__,
-          :"InvalidGetByActionResource#{System.unique_integer([:positive])}"
+      Module.create(
+        related,
+        quote do
+          use Ash.Resource,
+            domain: unquote(domain),
+            data_layer: Ash.DataLayer.Ets,
+            validate_domain_inclusion?: false
+
+          attributes do
+            uuid_v7_primary_key(:id, writable?: true)
+            attribute(:parent_id, :uuid, public?: true)
+          end
+
+          actions do
+            defaults([:read])
+          end
+        end,
+        Macro.Env.location(__ENV__)
+      )
+
+      assert_raise Spark.Error.DslError, ~r/cannot `get_by` on the relationship/, fn ->
+        Module.create(
+          resource,
+          quote do
+            use Ash.Resource,
+              domain: unquote(domain),
+              extensions: [AshAi],
+              data_layer: Ash.DataLayer.Ets,
+              validate_domain_inclusion?: false
+
+            attributes do
+              uuid_v7_primary_key(:id, writable?: true)
+            end
+
+            relationships do
+              has_many(:children, unquote(related),
+                public?: true,
+                destination_attribute: :parent_id
+              )
+            end
+
+            actions do
+              defaults([:read])
+            end
+
+            tools do
+              tool(:get_by_children, :read, get_by: :children)
+            end
+          end,
+          Macro.Env.location(__ENV__)
         )
+      end
+    end
+
+    test "rejects get_by on non-read tools at compile time", %{test: test} do
+      domain = Module.concat([__MODULE__, test, Domain])
+      resource = Module.concat([__MODULE__, test, Resource])
 
       assert_raise Spark.Error.DslError, ~r/only be used with read tools/, fn ->
         Module.create(

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -173,6 +173,39 @@ defmodule AshAi.ToolTest do
       other = Ash.get!(IdentityResource, 1, domain: IdentityDomain)
       assert other.name == "Name 1"
     end
+
+    test "casts identity values to the field type" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{IdentityResource, [:update]}],
+          strict: false
+        )
+
+      {:ok, _json, updated} =
+        registry["update_by_pk"].(
+          %{"id" => "2", "input" => %{"name" => "Renamed"}},
+          context()
+        )
+
+      assert updated.id == 2
+      assert updated.name == "Renamed"
+    end
+
+    test "returns a tool error when an identity value is not castable" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{IdentityResource, [:update]}],
+          strict: false
+        )
+
+      assert {:error, message} =
+               registry["update_by_pk"].(
+                 %{"id" => "not-an-integer", "input" => %{"name" => "Renamed"}},
+                 context()
+               )
+
+      assert message =~ "Invalid value for identity argument id"
+    end
   end
 
   describe "tool response" do

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -36,6 +36,13 @@ defmodule AshAi.ToolTest do
     tools do
       tool :read_test_resources, TestResource, :read, load: [:internal_status]
 
+      tool :get_test_resource_by_id, TestResource, :read,
+        get_by: :id,
+        load: [:internal_status]
+
+      tool :get_test_resource_by_name_and_email, TestResource, :read,
+        get_by: [:public_name, :public_email]
+
       tool :read_test_resources_full_filter, TestResource, :read, full_filter_schema?: true
 
       tool :read_test_resources_with_meta,
@@ -180,7 +187,11 @@ defmodule AshAi.ToolTest do
       {_tools, registry} =
         AshAi.build_tools_and_registry(actions: [{TestResource, :*}], strict: false)
 
-      {:ok, json, [fetched]} = registry["read_test_resources"].(%{}, context())
+      {:ok, json, [fetched]} =
+        registry["read_test_resources"].(
+          %{"filter" => %{"field" => "id", "operator" => "eq", "value" => resource.id}},
+          context()
+        )
 
       assert fetched.id == resource.id
       assert fetched.public_name == "John Doe"
@@ -223,6 +234,109 @@ defmodule AshAi.ToolTest do
       assert error =~ "`input` must be a JSON object"
       assert error =~ "..."
       assert String.length(error) < 300
+    end
+  end
+
+  describe "get_by read tools" do
+    setup do
+      id = Ash.UUIDv7.generate()
+
+      resource =
+        TestResource
+        |> Ash.Changeset.for_create(:create, %{
+          id: id,
+          public_name: "Jane #{id}",
+          public_email: "jane-#{id}@example.com",
+          private_notes: "Private lookup notes",
+          internal_status: "reviewed"
+        })
+        |> Ash.create!(domain: TestDomain)
+
+      %{resource: resource}
+    end
+
+    test "schema exposes lookup fields and not list-query controls" do
+      tool =
+        [actions: [{TestResource, [:read]}], tools: [:get_test_resource_by_id], strict: false]
+        |> AshAi.list_tools()
+        |> hd()
+
+      props = tool.parameter_schema["properties"]
+
+      assert Map.has_key?(props, "id")
+      assert tool.parameter_schema["required"] == ["id"]
+
+      refute Map.has_key?(props, "filter")
+      refute Map.has_key?(props, "sort")
+      refute Map.has_key?(props, "limit")
+      refute Map.has_key?(props, "offset")
+      refute Map.has_key?(props, "result_type")
+    end
+
+    test "executes by a single lookup field and returns one record", %{resource: resource} do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      {:ok, json, fetched} =
+        registry["get_test_resource_by_id"].(%{"id" => resource.id}, context())
+
+      assert fetched.id == resource.id
+
+      assert json ==
+               "{\"id\":\"#{resource.id}\",\"public_name\":\"Jane #{resource.id}\",\"public_email\":\"jane-#{resource.id}@example.com\",\"internal_status\":\"reviewed\"}"
+    end
+
+    test "executes by a composite lookup", %{resource: resource} do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_name_and_email],
+          strict: false
+        )
+
+      {:ok, _json, fetched} =
+        registry["get_test_resource_by_name_and_email"].(
+          %{
+            "public_name" => resource.public_name,
+            "public_email" => resource.public_email
+          },
+          context()
+        )
+
+      assert fetched.id == resource.id
+    end
+
+    test "returns a tool error when a lookup argument is missing" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:error, "Missing required get_by argument: id"} =
+               registry["get_test_resource_by_id"].(%{}, context())
+    end
+
+    test "returns a tool error when no record matches" do
+      {_tools, registry} =
+        AshAi.build_tools_and_registry(
+          actions: [{TestResource, [:read]}],
+          tools: [:get_test_resource_by_id],
+          strict: false
+        )
+
+      assert {:error, message} =
+               registry["get_test_resource_by_id"].(
+                 %{"id" => "0197b375-4daa-7112-a9d8-7f0104489999"},
+                 context()
+               )
+
+      assert message =~ "could not be found"
     end
   end
 
@@ -301,6 +415,85 @@ defmodule AshAi.ToolTest do
       tool_with_meta = Enum.find(tools, &(&1.name == :read_test_resources_with_meta))
 
       assert AshAi.Tool.has_meta?(tool_with_meta)
+    end
+  end
+
+  describe "get_by validation" do
+    test "rejects private lookup fields at compile time" do
+      domain =
+        Module.concat(__MODULE__, :"InvalidGetByDomain#{System.unique_integer([:positive])}")
+
+      resource =
+        Module.concat(__MODULE__, :"InvalidGetByResource#{System.unique_integer([:positive])}")
+
+      assert_raise Spark.Error.DslError, ~r/not public/, fn ->
+        Module.create(
+          resource,
+          quote do
+            use Ash.Resource,
+              domain: unquote(domain),
+              extensions: [AshAi],
+              data_layer: Ash.DataLayer.Ets,
+              validate_domain_inclusion?: false
+
+            attributes do
+              uuid_v7_primary_key(:id, writable?: true)
+              attribute(:private_name, :string)
+            end
+
+            actions do
+              defaults([:read])
+            end
+
+            tools do
+              tool(:get_by_private_name, :read, get_by: :private_name)
+            end
+          end,
+          Macro.Env.location(__ENV__)
+        )
+      end
+    end
+
+    test "rejects get_by on non-read tools at compile time" do
+      domain =
+        Module.concat(
+          __MODULE__,
+          :"InvalidGetByActionDomain#{System.unique_integer([:positive])}"
+        )
+
+      resource =
+        Module.concat(
+          __MODULE__,
+          :"InvalidGetByActionResource#{System.unique_integer([:positive])}"
+        )
+
+      assert_raise Spark.Error.DslError, ~r/only be used with read tools/, fn ->
+        Module.create(
+          resource,
+          quote do
+            use Ash.Resource,
+              domain: unquote(domain),
+              extensions: [AshAi],
+              data_layer: Ash.DataLayer.Ets,
+              validate_domain_inclusion?: false
+
+            attributes do
+              uuid_v7_primary_key(:id, writable?: true)
+              attribute(:name, :string, public?: true)
+            end
+
+            actions do
+              defaults([:read, :create])
+              default_accept([:name])
+            end
+
+            tools do
+              tool(:create_by_name, :create, get_by: :name)
+            end
+          end,
+          Macro.Env.location(__ENV__)
+        )
+      end
     end
   end
 

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -450,11 +450,11 @@ defmodule AshAi.ToolTest do
   end
 
   describe "get_by validation" do
-    test "rejects private lookup fields at compile time", %{test: test} do
+    test "rejects non-filterable lookup fields at compile time", %{test: test} do
       domain = Module.concat([__MODULE__, test, Domain])
       resource = Module.concat([__MODULE__, test, Resource])
 
-      assert_raise Spark.Error.DslError, ~r/not public/, fn ->
+      assert_raise Spark.Error.DslError, ~r/not filterable/, fn ->
         Module.create(
           resource,
           quote do
@@ -466,7 +466,7 @@ defmodule AshAi.ToolTest do
 
             attributes do
               uuid_v7_primary_key(:id, writable?: true)
-              attribute(:private_name, :string)
+              attribute(:name, :string, public?: true, filterable?: false)
             end
 
             actions do
@@ -474,7 +474,7 @@ defmodule AshAi.ToolTest do
             end
 
             tools do
-              tool(:get_by_private_name, :read, get_by: :private_name)
+              tool(:get_by_name, :read, get_by: :name)
             end
           end,
           Macro.Env.location(__ENV__)

--- a/test/ash_ai/tool_test.exs
+++ b/test/ash_ai/tool_test.exs
@@ -10,6 +10,10 @@ defmodule AshAi.ToolTest do
   defmodule TestResource do
     use Ash.Resource, domain: TestDomain, data_layer: Ash.DataLayer.Ets
 
+    ets do
+      private? true
+    end
+
     attributes do
       uuid_v7_primary_key(:id, writable?: true)
 
@@ -59,6 +63,10 @@ defmodule AshAi.ToolTest do
 
   defmodule IdentityResource do
     use Ash.Resource, domain: IdentityDomain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
 
     attributes do
       integer_primary_key :id, writable?: true
@@ -187,11 +195,7 @@ defmodule AshAi.ToolTest do
       {_tools, registry} =
         AshAi.build_tools_and_registry(actions: [{TestResource, :*}], strict: false)
 
-      {:ok, json, [fetched]} =
-        registry["read_test_resources"].(
-          %{"filter" => %{"field" => "id", "operator" => "eq", "value" => resource.id}},
-          context()
-        )
+      {:ok, json, [fetched]} = registry["read_test_resources"].(%{}, context())
 
       assert fetched.id == resource.id
       assert fetched.public_name == "John Doe"


### PR DESCRIPTION
Continuation of #206 by @Munksgaard, with the original commit preserved and rebased onto main. Adds a `get_by` option to tool definitions so a read tool can fetch a single record by one or more fields instead of returning a list.

```elixir
tools do
  tool :get_post_by_id, MyApp.Blog.Post, :read, get_by: :id
  tool :get_post_by_slug, MyApp.Blog.Post, :read, get_by: [:tenant_id, :slug]
end
```

A `get_by` read tool takes its lookup fields as required top-level arguments and omits the list-query controls (`filter`, `sort`, `limit`, `offset`, `result_type`), which trims the tool schema considerably.

## Changes on top of #206

**Aligned with core Ash's `get_by`**, which diverged in three ways:

- *Values weren't cast.* `{"serial": "42"}` against an integer attribute returned "could not be found" instead of matching, so a model that stringifies a number got a silent wrong answer. Values are now cast to the field's type.
- *Relationships were accepted, then crashed* at schema build with `function :has_many.embedded?/0 is undefined`. They are now rejected at compile time.
- *Private fields were rejected.* Core Ash validates `filterable?` only, and `get_by` names a field fixed in the DSL rather than one the model picks at call time, so it carries the same contract as `load:` and `select:`. The requirement was dropped.

**Fixed the same casting bug in `identity`.** Updating by an integer primary key with `{"id": "2"}` reported "could not be found". This predates the PR and takes the same fix.

**Isolated the test ETS tables.** #206 worked around cross-test leakage by adding an id filter to an existing test. With `private? true` that workaround is unnecessary and has been reverted.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [X] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
