### PR TITLE
feat(mcp): publish structured tool outputs

### DIFF
--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -984,23 +984,45 @@ defmodule AshAi.Mcp.Server do
   end
 
   defp execute_resolved_tool(tool, arguments, context) do
-    case AshAi.Tools.execute(tool, arguments, context) do
+    case AshAi.Tools.execute(tool, arguments, context, encode?: false) do
       {:ok, result, _} ->
-        result = %{
-          "isError" => false,
-          "content" => [%{"type" => "text", "text" => result}]
-        }
+        case encode_tool_result(tool, result) do
+          {:ok, encoded_result} ->
+            result =
+              %{
+                "isError" => false,
+                "content" => [%{"type" => "text", "text" => encoded_result}]
+              }
+              |> maybe_put_structured_content(result)
 
-        if Tool.has_meta?(tool) do
-          {:ok, Map.put(result, "_meta", tool._meta)}
-        else
-          {:ok, result}
+            if Tool.has_meta?(tool) do
+              {:ok, Map.put(result, "_meta", tool._meta)}
+            else
+              {:ok, result}
+            end
+
+          {:error, error_text} ->
+            {:ok, tool_error_result(error_text)}
         end
 
       {:error, error_text} ->
         {:ok, tool_error_result(error_text)}
     end
   end
+
+  defp encode_tool_result(%{action: %{type: :action, returns: nil}}, result), do: {:ok, result}
+
+  defp encode_tool_result(_tool, result) do
+    {:ok, Jason.encode!(result)}
+  rescue
+    error -> {:error, AshAi.Tool.Errors.format(error)}
+  end
+
+  defp maybe_put_structured_content(result, structured_content)
+       when is_map(structured_content),
+       do: Map.put(result, "structuredContent", structured_content)
+
+  defp maybe_put_structured_content(result, _structured_content), do: result
 
   defp tool_error_result(error_text) do
     %{

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -42,6 +42,8 @@ defmodule AshAi.Mcp.Server do
   @meta_client_capabilities "io.modelcontextprotocol/clientCapabilities"
   @meta_server_info "io.modelcontextprotocol/serverInfo"
   @meta_subscription_id "io.modelcontextprotocol/subscriptionId"
+  @ui_extension "io.modelcontextprotocol/ui"
+  @ui_mime_type "text/html;profile=mcp-app"
 
   @doc """
   The protocol versions this server supports, newest first.
@@ -302,11 +304,11 @@ defmodule AshAi.Mcp.Server do
 
   defp decode_header_value(value), do: {:ok, value}
 
-  defp dispatch_2026_07_28(conn, "server/discover", id, _params, opts) do
+  defp dispatch_2026_07_28(conn, "server/discover", id, params, opts) do
     result =
       %{
         "supportedVersions" => @supported_protocol_versions,
-        "capabilities" => opts |> mcp_resources() |> capabilities()
+        "capabilities" => capabilities(opts, client_capabilities_2026_07_28(params))
       }
       |> maybe_put("instructions", get_instructions(opts))
       |> cacheable_result(opts, :list)
@@ -690,10 +692,7 @@ defmodule AshAi.Mcp.Server do
             if(requested_version in @initialize_based_versions, do: requested_version) ||
             "2025-03-26"
 
-        capabilities =
-          opts
-          |> mcp_resources()
-          |> capabilities()
+        capabilities = capabilities(opts, params["capabilities"] || %{})
 
         result =
           %{
@@ -849,6 +848,43 @@ defmodule AshAi.Mcp.Server do
     do:
       capabilities([])
       |> Map.put("resources", %{})
+
+  defp capabilities(opts, client_capabilities) do
+    resources = mcp_resources(opts)
+
+    resources
+    |> capabilities()
+    |> maybe_add_ui_capability(resources, client_capabilities)
+  end
+
+  defp maybe_add_ui_capability(capabilities, resources, client_capabilities) do
+    if ui_capable?(client_capabilities) &&
+         Enum.any?(resources, &match?(%AshAi.McpUiResource{}, &1)) do
+      ui_capability = %{"mimeTypes" => [@ui_mime_type]}
+
+      Map.update(
+        capabilities,
+        "extensions",
+        %{@ui_extension => ui_capability},
+        &Map.put(&1, @ui_extension, ui_capability)
+      )
+    else
+      capabilities
+    end
+  end
+
+  defp client_capabilities_2026_07_28(params) do
+    get_in(params, ["_meta", @meta_client_capabilities]) || %{}
+  end
+
+  defp ui_capable?(client_capabilities) do
+    client_capabilities
+    |> get_in(["extensions", @ui_extension, "mimeTypes"])
+    |> case do
+      mime_types when is_list(mime_types) -> @ui_mime_type in mime_types
+      _ -> false
+    end
+  end
 
   defp mcp_resources(opts) do
     mcp_action_resources(opts) ++ mcp_ui_resources(opts)

--- a/lib/ash_ai/tool/execution.ex
+++ b/lib/ash_ai/tool/execution.ex
@@ -15,15 +15,26 @@ defmodule AshAi.Tool.Execution do
     @moduledoc """
     Execution context for tool calls.
     """
-    defstruct [:actor, :tenant, :context, :load, :select, :domain, load_strict?: false]
+    defstruct [
+      :actor,
+      :tenant,
+      :context,
+      :load,
+      :select,
+      :domain,
+      encode?: true,
+      load_strict?: false
+    ]
   end
 
   @doc """
   Executes a tool with the given arguments and context.
 
   Returns:
-  - `{:ok, json_result, raw_result}` for successful tool calls
+  - `{:ok, result, raw_result}` for successful tool calls
   - `{:error, error_text}` for execution failures
+
+  Set `:encode?` to `false` to return the serialized result before JSON encoding.
   """
   def run(
         %AshAi.Tool{
@@ -38,7 +49,8 @@ defmodule AshAi.Tool.Execution do
           arguments: tool_arguments
         },
         client_arguments,
-        context
+        context,
+        run_opts \\ []
       ) do
     arguments = client_arguments || %{}
     client_input = arguments["input"] || %{}
@@ -60,7 +72,8 @@ defmodule AshAi.Tool.Execution do
         load: resolved_load,
         load_strict?: load_strict?,
         select: select,
-        domain: domain
+        domain: domain,
+        encode?: Keyword.get(run_opts, :encode?, true)
       }
 
       try do
@@ -209,7 +222,7 @@ defmodule AshAi.Tool.Execution do
 
       result
       |> AshAi.Serializer.serialize_value({:array, resource}, [], ctx.domain, serialize_opts(ctx))
-      |> Jason.encode!()
+      |> encode_result(ctx)
       |> then(&{:ok, &1, result})
     end)
   end
@@ -225,7 +238,7 @@ defmodule AshAi.Tool.Execution do
     |> then(fn result ->
       result
       |> AshAi.Serializer.serialize_value(Ash.Type.Integer, [], ctx.domain)
-      |> Jason.encode!()
+      |> encode_result(ctx)
       |> then(&{:ok, &1, result})
     end)
   end
@@ -240,7 +253,7 @@ defmodule AshAi.Tool.Execution do
     |> then(fn result ->
       result
       |> AshAi.Serializer.serialize_value(Ash.Type.Boolean, [], ctx.domain)
-      |> Jason.encode!()
+      |> encode_result(ctx)
       |> then(&{:ok, &1, result})
     end)
   end
@@ -285,7 +298,7 @@ defmodule AshAi.Tool.Execution do
         aggregate_constraints,
         ctx.domain
       )
-      |> Jason.encode!()
+      |> encode_result(ctx)
       |> then(&{:ok, &1, result})
     end)
   end
@@ -357,7 +370,7 @@ defmodule AshAi.Tool.Execution do
   defp serialize_record(result, resource, ctx) do
     result
     |> AshAi.Serializer.serialize_value(resource, [], ctx.domain, serialize_opts(ctx))
-    |> Jason.encode!()
+    |> encode_result(ctx)
     |> then(&{:ok, &1, result})
   end
 
@@ -374,13 +387,16 @@ defmodule AshAi.Tool.Execution do
           ctx.domain,
           load: ctx.load
         )
-        |> Jason.encode!()
+        |> encode_result(ctx)
       else
         "success"
       end
       |> then(&{:ok, &1, result})
     end)
   end
+
+  defp encode_result(result, %Context{encode?: true}), do: Jason.encode!(result)
+  defp encode_result(result, %Context{encode?: false}), do: result
 
   defp identity_filter(false, _resource, _arguments), do: nil
 

--- a/lib/ash_ai/tools.ex
+++ b/lib/ash_ai/tools.ex
@@ -35,12 +35,14 @@ defmodule AshAi.Tools do
   @doc """
   Executes a tool with the given arguments and context.
 
-  Delegates to `AshAi.Tool.Execution.run/3`.
+  Delegates to `AshAi.Tool.Execution.run/4`.
 
-  Returns `{:ok, json_result, raw_result}` on success or `{:error, json_error}` on failure.
+  Returns `{:ok, result, raw_result}` on success or `{:error, json_error}` on failure.
+  By default, `result` is JSON-encoded text. Set `:encode?` to `false` to return
+  the serialized value before JSON encoding.
   """
-  def execute(%Tool{} = tool, arguments, context) do
-    Execution.run(tool, arguments, context)
+  def execute(%Tool{} = tool, arguments, context, opts \\ []) do
+    Execution.run(tool, arguments, context, opts)
   end
 
   @doc """

--- a/test/ash_ai/mcp/structured_outputs_test.exs
+++ b/test/ash_ai/mcp/structured_outputs_test.exs
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAi.Mcp.StructuredOutputsTest do
+  use ExUnit.Case, async: true
+  import Plug.{Conn, Test}
+
+  alias AshAi.Mcp.Router
+
+  defmodule Result do
+    use Ash.TypedStruct
+
+    typed_struct do
+      field :created_at, :utc_datetime, allow_nil?: false
+      field :status, :atom, allow_nil?: false, constraints: [one_of: [:ready, :pending]]
+    end
+  end
+
+  defmodule DiscoveryOnly do
+    use Ash.Policy.SimpleCheck
+
+    def match?(_actor, %{context: %{private: %{ash_ai_pre_check?: true}}}, _opts), do: true
+    def match?(_actor, _context, _opts), do: false
+    def describe(_opts), do: "allowed only during tool discovery"
+  end
+
+  defmodule Resource do
+    use Ash.Resource,
+      domain: AshAi.Mcp.StructuredOutputsTest.Domain,
+      authorizers: [Ash.Policy.Authorizer],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true, allow_nil?: false
+    end
+
+    actions do
+      create :create_record do
+        accept [:name]
+      end
+
+      action :typed_result, Result do
+        run fn _input, _context ->
+          send(self(), :typed_result_executed)
+          {:ok, Result.new!(%{created_at: ~U[2026-08-11 12:30:00Z], status: :ready})}
+        end
+      end
+
+      action :map_result, :map do
+        run fn _input, _context -> {:ok, %{runtime: "shape"}} end
+      end
+
+      action :scalar_result, :string do
+        run fn _input, _context -> {:ok, "scalar"} end
+      end
+
+      action :array_result, {:array, :integer} do
+        run fn _input, _context -> {:ok, [1, 2]} end
+      end
+
+      action :nil_result, :map do
+        allow_nil? true
+        run fn _input, _context -> {:ok, nil} end
+      end
+
+      action :unencodable_result, :map do
+        run fn _input, _context -> {:ok, %{pid: self()}} end
+      end
+
+      action :failing_result, :map do
+        run fn _input, _context -> {:error, "failed intentionally"} end
+      end
+
+      action :cast_failure, :map do
+        argument :count, :integer, allow_nil?: false
+        run fn _input, _context -> {:error, "should not execute"} end
+      end
+
+      action :protected_result, :map do
+        run fn _input, _context -> {:error, "should not execute"} end
+      end
+    end
+
+    policies do
+      policy action(:protected_result) do
+        authorize_if DiscoveryOnly
+      end
+
+      policy always() do
+        authorize_if always()
+      end
+    end
+  end
+
+  defmodule Domain do
+    use Ash.Domain, extensions: [AshAi]
+
+    resources do
+      resource Resource
+    end
+
+    tools do
+      tool :typed_result, Resource, :typed_result,
+        _meta: %{"ui" => %{"resourceUri" => "ui://example/result.html"}}
+
+      tool :create_record, Resource, :create_record
+      tool :map_result, Resource, :map_result
+      tool :scalar_result, Resource, :scalar_result
+      tool :array_result, Resource, :array_result
+      tool :nil_result, Resource, :nil_result
+      tool :unencodable_result, Resource, :unencodable_result
+      tool :failing_result, Resource, :failing_result
+      tool :cast_failure, Resource, :cast_failure
+      tool :protected_result, Resource, :protected_result
+    end
+  end
+
+  @opts [actions: [{Resource, :*}], mcp_resources: []]
+
+  describe "initialize-based public router" do
+    test "returns serialized JSON objects as structured content and preserves text" do
+      session_id = initialize()
+      tools = session_id |> request("tools/list", %{}) |> result() |> Map.fetch!("tools")
+      typed_tool = find_tool(tools, "typed_result")
+
+      assert typed_tool["_meta"]["ui"]["resourceUri"] == "ui://example/result.html"
+
+      typed_result = call_tool(session_id, "typed_result")
+      [%{"type" => "text", "text" => typed_text}] = typed_result["content"]
+
+      assert typed_result["isError"] == false
+      assert typed_result["_meta"] == typed_tool["_meta"]
+      assert typed_result["structuredContent"] == Jason.decode!(typed_text)
+      assert typed_result["structuredContent"]["status"] == "ready"
+      assert typed_result["structuredContent"]["created_at"] == "2026-08-11T12:30:00Z"
+      assert_received :typed_result_executed
+      refute_received :typed_result_executed
+
+      map_result = call_tool(session_id, "map_result")
+      [%{"type" => "text", "text" => map_text}] = map_result["content"]
+      assert map_result["structuredContent"] == Jason.decode!(map_text)
+
+      create_result =
+        call_tool(session_id, "create_record", %{"input" => %{"name" => "created"}})
+
+      [%{"type" => "text", "text" => create_text}] = create_result["content"]
+      assert create_result["structuredContent"] == Jason.decode!(create_text)
+      assert create_result["structuredContent"]["name"] == "created"
+    end
+
+    test "preserves text-only behavior for non-object results" do
+      session_id = initialize()
+
+      for name <- ["scalar_result", "array_result", "nil_result"] do
+        call_result = call_tool(session_id, name)
+
+        assert call_result["isError"] == false
+        assert [%{"type" => "text", "text" => _text}] = call_result["content"]
+        refute Map.has_key?(call_result, "structuredContent")
+      end
+    end
+
+    test "casting, authorization, and execution errors never contain structured content" do
+      session_id = initialize()
+
+      calls = [
+        {"cast_failure", %{"input" => %{"count" => "not-an-integer"}}},
+        {"protected_result", %{}},
+        {"failing_result", %{}},
+        {"unencodable_result", %{}}
+      ]
+
+      for {name, arguments} <- calls do
+        call_result = call_tool(session_id, name, arguments)
+
+        assert call_result["isError"] == true,
+               "expected #{name} to return a tool error, got: #{inspect(call_result)}"
+
+        refute Map.has_key?(call_result, "structuredContent")
+      end
+    end
+  end
+
+  describe "2026-07-28 public router" do
+    test "returns the same structured content without a session" do
+      call_result =
+        per_request("tools/call", %{"name" => "map_result", "arguments" => %{}})
+        |> result()
+
+      [%{"text" => text}] = call_result["content"]
+      assert call_result["structuredContent"] == Jason.decode!(text)
+    end
+  end
+
+  defp initialize do
+    response =
+      conn(:post, "/", %{
+        "jsonrpc" => "2.0",
+        "id" => "init",
+        "method" => "initialize",
+        "params" => %{"protocolVersion" => "2025-06-18", "capabilities" => %{}}
+      })
+      |> Router.call(@opts)
+
+    response
+    |> get_resp_header("mcp-session-id")
+    |> List.first()
+  end
+
+  defp request(session_id, method, params) do
+    conn(:post, "/", %{"jsonrpc" => "2.0", "id" => method, "method" => method, "params" => params})
+    |> put_req_header("mcp-session-id", session_id)
+    |> Router.call(@opts)
+  end
+
+  defp call_tool(session_id, name, arguments \\ %{}) do
+    session_id
+    |> request("tools/call", %{"name" => name, "arguments" => arguments})
+    |> result()
+  end
+
+  defp per_request(method, params) do
+    params = Map.put(params, "_meta", request_meta())
+
+    conn(:post, "/", %{"jsonrpc" => "2.0", "id" => method, "method" => method, "params" => params})
+    |> put_req_header("mcp-protocol-version", "2026-07-28")
+    |> put_req_header("mcp-method", method)
+    |> put_req_header("mcp-name", params["name"])
+    |> Router.call(@opts)
+  end
+
+  defp request_meta do
+    %{
+      "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities" => %{},
+      "io.modelcontextprotocol/clientInfo" => %{"name" => "test", "version" => "1"}
+    }
+  end
+
+  defp result(response), do: Jason.decode!(response.resp_body)["result"]
+  defp find_tool(tools, name), do: Enum.find(tools, &(&1["name"] == name))
+end

--- a/test/ash_ai/mcp/ui_resources_test.exs
+++ b/test/ash_ai/mcp/ui_resources_test.exs
@@ -12,6 +12,8 @@ defmodule AshAi.Mcp.UiResourcesTest do
   alias AshAi.Mcp.Router
 
   @opts [otp_app: :ash_ai]
+  @ui_extension "io.modelcontextprotocol/ui"
+  @ui_mime_type "text/html;profile=mcp-app"
 
   describe "mcp_ui_resource in resources/list" do
     test "includes UI resources in the resource list" do
@@ -115,6 +117,69 @@ defmodule AshAi.Mcp.UiResourcesTest do
     end
   end
 
+  describe "MCP Apps extension negotiation" do
+    test "initialize advertises the stable extension for a capable client" do
+      response = initialize_with_capabilities(@opts, ui_capabilities())
+      capabilities = decode_response(response)["result"]["capabilities"]
+
+      assert capabilities["extensions"][@ui_extension] == %{
+               "mimeTypes" => [@ui_mime_type]
+             }
+    end
+
+    test "initialize omits the extension for a client without the supported MIME type" do
+      response = initialize_with_capabilities(@opts, %{})
+      capabilities = decode_response(response)["result"]["capabilities"]
+
+      refute Map.has_key?(capabilities, "extensions")
+    end
+
+    test "a non-App client retains the native UI-linked tool and text result" do
+      response = initialize_with_capabilities(@opts, %{})
+      session_id = extract_session_id(response)
+
+      tool_response =
+        conn(:post, "/", %{"method" => "tools/list", "id" => "list_tools"})
+        |> put_req_header("mcp-session-id", session_id)
+        |> Router.call(tools: [:list_artists_with_ui], otp_app: :ash_ai)
+
+      [tool] = decode_response(tool_response)["result"]["tools"]
+      assert tool["_meta"]["ui"]["resourceUri"] == "ui://test/app.html"
+
+      call_response =
+        conn(:post, "/", %{
+          "method" => "tools/call",
+          "id" => "call_tool",
+          "params" => %{"name" => "list_artists_with_ui", "arguments" => %{}}
+        })
+        |> put_req_header("mcp-session-id", session_id)
+        |> Router.call(tools: [:list_artists_with_ui], otp_app: :ash_ai)
+
+      result = decode_response(call_response)["result"]
+      assert result["isError"] == false
+      assert [%{"type" => "text", "text" => text}] = result["content"]
+      assert is_list(Jason.decode!(text))
+    end
+
+    test "2026-07-28 server discovery negotiates the extension per request" do
+      capable = discover_2026_07_28(@opts, ui_capabilities())
+      incapable = discover_2026_07_28(@opts, %{})
+
+      assert capable["capabilities"]["extensions"][@ui_extension] == %{
+               "mimeTypes" => [@ui_mime_type]
+             }
+
+      refute Map.has_key?(incapable["capabilities"], "extensions")
+    end
+
+    test "servers without UI resources do not advertise the extension" do
+      response = initialize_with_capabilities([actions: [], mcp_resources: []], ui_capabilities())
+      capabilities = decode_response(response)["result"]["capabilities"]
+
+      refute Map.has_key?(capabilities, "extensions")
+    end
+  end
+
   # Helper functions
 
   defp initialize_and_get_session_id(opts) do
@@ -127,6 +192,49 @@ defmodule AshAi.Mcp.UiResourcesTest do
       |> Router.call(opts)
 
     extract_session_id(response)
+  end
+
+  defp initialize_with_capabilities(opts, capabilities) do
+    conn(:post, "/", %{
+      "method" => "initialize",
+      "id" => "init_capabilities",
+      "params" => %{
+        "protocolVersion" => "2025-06-18",
+        "capabilities" => capabilities,
+        "clientInfo" => %{"name" => "test_client", "version" => "1.0.0"}
+      }
+    })
+    |> Router.call(opts)
+  end
+
+  defp discover_2026_07_28(opts, client_capabilities) do
+    method = "server/discover"
+
+    meta = %{
+      "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities" => client_capabilities,
+      "io.modelcontextprotocol/clientInfo" => %{"name" => "test_client", "version" => "1.0.0"}
+    }
+
+    conn(:post, "/", %{
+      "jsonrpc" => "2.0",
+      "id" => "discover",
+      "method" => method,
+      "params" => %{"_meta" => meta}
+    })
+    |> put_req_header("mcp-protocol-version", "2026-07-28")
+    |> put_req_header("mcp-method", method)
+    |> Router.call(opts)
+    |> decode_response()
+    |> Map.fetch!("result")
+  end
+
+  defp ui_capabilities do
+    %{
+      "extensions" => %{
+        @ui_extension => %{"mimeTypes" => [@ui_mime_type]}
+      }
+    }
   end
 
   defp list_resources(session_id, opts) do


### PR DESCRIPTION
# Summary

This completes the MCP Apps data path: object-shaped tool results are returned as structuredContent, while the existing text response remains available for compatibility.

It also negotiates MCP Apps support across both protocol paths so clients can discover that behavior.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
