### PR TITLE
feat: make req_llm an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ You can install `AshAi` using igniter. For example:
 mix igniter.install ash_ai
 ```
 
+The installer also adds `req_llm`, which powers every feature that calls an LLM.
+If you only want to serve tools over MCP, pass `--no-req-llm` to skip it.
+
 ### Manually
 
 Add `AshAi` to your list of dependencies:
@@ -33,7 +36,10 @@ Add `AshAi` to your list of dependencies:
 ```elixir
 def deps do
   [
-    {:ash_ai, "~> 0.2"}
+    {:ash_ai, "~> 0.2"},
+    # Optional: required for prompt-backed actions, `AshAi.ToolLoop`,
+    # `mix ash_ai.gen.chat` and ReqLLM embeddings. Not needed for MCP only.
+    {:req_llm, "~> 1.7"}
   ]
 end
 ```

--- a/lib/ash_ai.ex
+++ b/lib/ash_ai.ex
@@ -7,8 +7,6 @@ defmodule AshAi do
   Documentation for `AshAi`.
   """
 
-  alias ReqLLM.Context
-
   defstruct []
 
   require Logger
@@ -458,59 +456,65 @@ defmodule AshAi do
 
   def build_tools_and_registry(opts), do: AshAi.Tools.build_tools_and_registry(opts)
 
-  @doc """
-  Interactive IEx chat loop powered by ReqLLM.
-  """
-  def iex_chat(opts \\ []) do
-    validated_opts = Options.validate!(opts)
+  if Code.ensure_loaded?(ReqLLM) do
+    alias ReqLLM.Context
 
-    base_messages =
-      case validated_opts.system_prompt do
-        :none ->
-          []
+    @doc """
+    Interactive IEx chat loop powered by ReqLLM.
+    """
+    def iex_chat(opts \\ []) do
+      validated_opts = Options.validate!(opts)
 
-        nil ->
-          [
-            Context.system("""
-            You are a helpful assistant.
-            Your purpose is to operate the application on behalf of the user.
-            """)
-          ]
+      base_messages =
+        case validated_opts.system_prompt do
+          :none ->
+            []
 
-        system_prompt ->
-          [Context.system(system_prompt.(validated_opts))]
+          nil ->
+            [
+              Context.system("""
+              You are a helpful assistant.
+              Your purpose is to operate the application on behalf of the user.
+              """)
+            ]
+
+          system_prompt ->
+            [Context.system(system_prompt.(validated_opts))]
+        end
+
+      run_iex_loop(base_messages, opts)
+    end
+
+    defp run_iex_loop(messages, opts) do
+      case AshAi.ToolLoop.run(messages, opts) do
+        {:ok, %AshAi.ToolLoop.Result{messages: updated_messages, final_text: final_text}} ->
+          if final_text != "" do
+            IO.puts(final_text)
+          end
+
+          case get_user_message() do
+            :eof ->
+              :ok
+
+            user_message ->
+              run_iex_loop(updated_messages ++ [Context.user(user_message)], opts)
+          end
+
+        {:error, error} ->
+          raise "Something went wrong:\n #{inspect(error)}"
       end
-
-    run_iex_loop(base_messages, opts)
-  end
-
-  defp run_iex_loop(messages, opts) do
-    case AshAi.ToolLoop.run(messages, opts) do
-      {:ok, %AshAi.ToolLoop.Result{messages: updated_messages, final_text: final_text}} ->
-        if final_text != "" do
-          IO.puts(final_text)
-        end
-
-        case get_user_message() do
-          :eof ->
-            :ok
-
-          user_message ->
-            run_iex_loop(updated_messages ++ [Context.user(user_message)], opts)
-        end
-
-      {:error, error} ->
-        raise "Something went wrong:\n #{inspect(error)}"
     end
-  end
 
-  defp get_user_message do
-    case Mix.shell().prompt("> ") do
-      nil -> :eof
-      "" -> get_user_message()
-      "\n" -> get_user_message()
-      message -> message
+    defp get_user_message do
+      case Mix.shell().prompt("> ") do
+        nil -> :eof
+        "" -> get_user_message()
+        "\n" -> get_user_message()
+        message -> message
+      end
     end
+  else
+    def iex_chat(_opts \\ []), do: AshAi.Dependencies.require_req_llm!("`AshAi.iex_chat/1`")
   end
 
   @doc false

--- a/lib/ash_ai/actions/prompt.ex
+++ b/lib/ash_ai/actions/prompt.ex
@@ -2,563 +2,578 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAi.Actions.Prompt do
-  require Logger
-  alias __MODULE__.FlowState
+if Code.ensure_loaded?(ReqLLM) do
+  defmodule AshAi.Actions.Prompt do
+    require Logger
+    alias __MODULE__.FlowState
 
-  @prompt_template {"""
-                    You are responsible for performing the `<%= @input.action.name %>` action.
+    @prompt_template {"""
+                      You are responsible for performing the `<%= @input.action.name %>` action.
 
-                    <%= if @input.action.description do %>
-                    # Description
-                    <%= @input.action.description %>
-                    <% end %>
+                      <%= if @input.action.description do %>
+                      # Description
+                      <%= @input.action.description %>
+                      <% end %>
 
-                    ## Inputs
-                    <%= for argument <- @input.action.arguments do %>
-                    - <%= argument.name %><%= if argument.description do %>: <%= argument.description %>
-                    <% end %>
-                    <% end %>
-                    """,
-                    """
-                    # Action Inputs
+                      ## Inputs
+                      <%= for argument <- @input.action.arguments do %>
+                      - <%= argument.name %><%= if argument.description do %>: <%= argument.description %>
+                      <% end %>
+                      <% end %>
+                      """,
+                      """
+                      # Action Inputs
 
-                    <%= for argument <- @input.action.arguments,
-                        {:ok, value} = Ash.ActionInput.fetch_argument(@input, argument.name),
-                        {:ok, value} = Ash.Type.dump_to_embedded(argument.type, value, argument.constraints) do %>
-                      - <%= argument.name %>: <%= Jason.encode!(value) %>
-                    <% end %>
-                    """}
-  @moduledoc """
-  A generic action impl that returns structured outputs from an LLM matching the action return.
+                      <%= for argument <- @input.action.arguments,
+                          {:ok, value} = Ash.ActionInput.fetch_argument(@input, argument.name),
+                          {:ok, value} = Ash.Type.dump_to_embedded(argument.type, value, argument.constraints) do %>
+                        - <%= argument.name %>: <%= Jason.encode!(value) %>
+                      <% end %>
+                      """}
+    @moduledoc """
+    A generic action impl that returns structured outputs from an LLM matching the action return.
 
-  Uses ReqLLM for structured output generation with model specifications as strings.
+    Uses ReqLLM for structured output generation with model specifications as strings.
 
-  ## Example
+    ## Example
 
-  ```elixir
-  action :analyze_sentiment, :atom do
-    constraints one_of: [:positive, :negative]
+    ```elixir
+    action :analyze_sentiment, :atom do
+      constraints one_of: [:positive, :negative]
 
-    description \"\"\"
-    Analyzes the sentiment of a given piece of text to determine if it is overall positive or negative.
-    \"\"\"
+      description \"\"\"
+      Analyzes the sentiment of a given piece of text to determine if it is overall positive or negative.
+      \"\"\"
 
-    argument :text, :string do
-      allow_nil? false
-      description "The text for analysis."
+      argument :text, :string do
+        allow_nil? false
+        description "The text for analysis."
+      end
+
+      run prompt("openai:gpt-4o",
+        prompt: {"You are a sentiment analyzer", "Analyze: <%= @input.arguments.text %>"}
+      )
     end
+    ```
+
+    ## Model Specification
+
+    The first argument to `prompt/2` is a model specification string in the format `"provider:model-name"`.
+    Valid model strings can be browsed at https://llmdb.xyz.
+    Examples: `"openai:gpt-4o"`, `"anthropic:claude-haiku-4-5"`, `"openai:gpt-4o-mini"`.
+
+    ## Options
+
+    - `:prompt` - A custom prompt. Supports multiple formats - see the prompt section below.
+    - `:req_llm` - Override the ReqLLM module (useful for testing with mocks).
+    - `:req_llm_opts` - Additional ReqLLM request options passed through to generation and tool loops.
+    - `:transform_flow` - ReqLLM-native flow customization hook (`fn flow_state, context -> flow_state end`).
+    - `:tools` - `false`, `true`, or a list of tool names to allow tool-calling in the action.
+    - `:extra_tools` - Additional arbitrary `ReqLLM.Tool`s to expose during tool-calling.
+    - `:max_iterations` - Maximum tool-loop iterations. Defaults to `:infinity` for prompt actions.
+    - `:verbose?` - When true, logs tool-loop lifecycle events with `Logger.debug/1`.
+
+    ## Behavior Notes
+
+    - Tool-loop failures are returned as action errors with loop reason details.
+    - Unconstrained `:map` return types use a permissive map schema (`type: object`).
+
+    ## Prompt Formats
+
+    The prompt by default is generated using the action and input descriptions. You can provide your own prompt
+    via the `prompt` option which supports multiple formats:
+
+    ### Supported Formats
+
+    1. **String (EEx template)**: `"Analyze this: <%= @input.arguments.text %>"`
+    2. **{System, User} tuple**: `{"You are an expert", "Analyze: <%= @input.arguments.text %>"}`
+    3. **ReqLLM.Context**: Pass a context directly (canonical format)
+    4. **List of messages**: Maps with role/content, ReqLLM.Message structs, or mixed
+    5. **Function returning any of the above**: `fn input, context -> ... end`
+
+    ### Using ReqLLM.Context (Recommended)
+
+    ```elixir
+    import ReqLLM.Context
 
     run prompt("openai:gpt-4o",
-      prompt: {"You are a sentiment analyzer", "Analyze: <%= @input.arguments.text %>"}
-    )
-  end
-  ```
-
-  ## Model Specification
-
-  The first argument to `prompt/2` is a model specification string in the format `"provider:model-name"`.
-  Valid model strings can be browsed at https://llmdb.xyz.
-  Examples: `"openai:gpt-4o"`, `"anthropic:claude-haiku-4-5"`, `"openai:gpt-4o-mini"`.
-
-  ## Options
-
-  - `:prompt` - A custom prompt. Supports multiple formats - see the prompt section below.
-  - `:req_llm` - Override the ReqLLM module (useful for testing with mocks).
-  - `:req_llm_opts` - Additional ReqLLM request options passed through to generation and tool loops.
-  - `:transform_flow` - ReqLLM-native flow customization hook (`fn flow_state, context -> flow_state end`).
-  - `:tools` - `false`, `true`, or a list of tool names to allow tool-calling in the action.
-  - `:extra_tools` - Additional arbitrary `ReqLLM.Tool`s to expose during tool-calling.
-  - `:max_iterations` - Maximum tool-loop iterations. Defaults to `:infinity` for prompt actions.
-  - `:verbose?` - When true, logs tool-loop lifecycle events with `Logger.debug/1`.
-
-  ## Behavior Notes
-
-  - Tool-loop failures are returned as action errors with loop reason details.
-  - Unconstrained `:map` return types use a permissive map schema (`type: object`).
-
-  ## Prompt Formats
-
-  The prompt by default is generated using the action and input descriptions. You can provide your own prompt
-  via the `prompt` option which supports multiple formats:
-
-  ### Supported Formats
-
-  1. **String (EEx template)**: `"Analyze this: <%= @input.arguments.text %>"`
-  2. **{System, User} tuple**: `{"You are an expert", "Analyze: <%= @input.arguments.text %>"}`
-  3. **ReqLLM.Context**: Pass a context directly (canonical format)
-  4. **List of messages**: Maps with role/content, ReqLLM.Message structs, or mixed
-  5. **Function returning any of the above**: `fn input, context -> ... end`
-
-  ### Using ReqLLM.Context (Recommended)
-
-  ```elixir
-  import ReqLLM.Context
-
-  run prompt("openai:gpt-4o",
-    prompt: fn input, _ctx ->
-      ReqLLM.Context.new([
-        system("You are an OCR expert"),
-        user([
-          ReqLLM.Message.ContentPart.text("Extract text from this image"),
-          ReqLLM.Message.ContentPart.image_url(input.arguments.image_url)
+      prompt: fn input, _ctx ->
+        ReqLLM.Context.new([
+          system("You are an OCR expert"),
+          user([
+            ReqLLM.Message.ContentPart.text("Extract text from this image"),
+            ReqLLM.Message.ContentPart.image_url(input.arguments.image_url)
+          ])
         ])
-      ])
-    end
-  )
-  ```
-
-  ### Legacy Map Format
-
-  For convenience, loose maps with role/content keys are also supported:
-
-  ```elixir
-  [
-    %{role: "system", content: "You are an OCR expert"},
-    %{role: "user", content: "Extract text: <%= @input.arguments.text %>"}
-  ]
-  ```
-
-  The default prompt template is:
-
-  ```elixir
-  #{inspect(@prompt_template, pretty: true)}
-  ```
-  """
-  use Ash.Resource.Actions.Implementation
-
-  def run(input, opts, context) do
-    model = resolve_model_spec(opts[:model], input, context)
-    schema = build_json_schema(input)
-    initial_context = build_context(input, opts, context)
-
-    req_llm_module = Keyword.get(opts, :req_llm, ReqLLM)
-    req_llm_opts = Keyword.get(opts, :req_llm_opts, [])
-
-    flow_state =
-      build_flow_state(initial_context, model, req_llm_module, req_llm_opts, context, opts)
-
-    with {:ok, flow_state} <- apply_flow_customizations(flow_state, context, opts),
-         {:ok, final_context} <- maybe_run_tools(flow_state, input, opts),
-         {:ok, generated} <-
-           flow_state.req_llm.generate_object(
-             flow_state.model,
-             final_context,
-             schema,
-             flow_state.req_llm_opts
-           ) do
-      case generated do
-        %{object: result} ->
-          cast_result(result, input.action)
-
-        result when is_map(result) ->
-          cast_result(result, input.action)
       end
-    else
-      {:error, error} ->
-        {:error, error}
+    )
+    ```
+
+    ### Legacy Map Format
+
+    For convenience, loose maps with role/content keys are also supported:
+
+    ```elixir
+    [
+      %{role: "system", content: "You are an OCR expert"},
+      %{role: "user", content: "Extract text: <%= @input.arguments.text %>"}
+    ]
+    ```
+
+    The default prompt template is:
+
+    ```elixir
+    #{inspect(@prompt_template, pretty: true)}
+    ```
+    """
+    use Ash.Resource.Actions.Implementation
+
+    def run(input, opts, context) do
+      model = resolve_model_spec(opts[:model], input, context)
+      schema = build_json_schema(input)
+      initial_context = build_context(input, opts, context)
+
+      req_llm_module = Keyword.get(opts, :req_llm, ReqLLM)
+      req_llm_opts = Keyword.get(opts, :req_llm_opts, [])
+
+      flow_state =
+        build_flow_state(initial_context, model, req_llm_module, req_llm_opts, context, opts)
+
+      with {:ok, flow_state} <- apply_flow_customizations(flow_state, context, opts),
+           {:ok, final_context} <- maybe_run_tools(flow_state, input, opts),
+           {:ok, generated} <-
+             flow_state.req_llm.generate_object(
+               flow_state.model,
+               final_context,
+               schema,
+               flow_state.req_llm_opts
+             ) do
+        case generated do
+          %{object: result} ->
+            cast_result(result, input.action)
+
+          result when is_map(result) ->
+            cast_result(result, input.action)
+        end
+      else
+        {:error, error} ->
+          {:error, error}
+      end
     end
-  end
 
-  defp resolve_model_spec(model, input, context) when is_function(model, 2) do
-    resolve_model_spec(model.(input, context), input, context)
-  end
-
-  defp resolve_model_spec(model, input, context) when is_function(model, 1) do
-    resolve_model_spec(model.(input), input, context)
-  end
-
-  defp resolve_model_spec(model, _input, _context) when is_function(model, 0) do
-    model.()
-  end
-
-  defp resolve_model_spec(model, _input, _context), do: model
-
-  defp build_flow_state(reqllm_context, model, req_llm_module, req_llm_opts, context, opts) do
-    %FlowState{
-      model: model,
-      req_llm: req_llm_module,
-      req_llm_opts: req_llm_opts,
-      messages: reqllm_context.messages,
-      tool_selection: Keyword.get(opts, :tools, false),
-      extra_tools: Keyword.get(opts, :extra_tools, []),
-      max_iterations: Keyword.get(opts, :max_iterations, :infinity),
-      strict: Keyword.get(opts, :strict, true),
-      verbose?: Keyword.get(opts, :verbose?, false),
-      on_tool_start: opts[:on_tool_start],
-      on_tool_end: opts[:on_tool_end],
-      actor: Map.get(context, :actor),
-      tenant: Map.get(context, :tenant),
-      source_context: Map.get(context, :source_context) || %{}
-    }
-  end
-
-  defp apply_flow_customizations(flow_state, context, opts) do
-    apply_transform_flow(flow_state, opts[:transform_flow], context)
-  end
-
-  defp apply_transform_flow(flow_state, nil, _context), do: {:ok, flow_state}
-
-  defp apply_transform_flow(flow_state, transform_flow, context)
-       when is_function(transform_flow, 2) do
-    case run_flow_callback(:transform_flow, fn -> transform_flow.(flow_state, context) end) do
-      {:ok, %FlowState{} = transformed} ->
-        {:ok, transformed}
-
-      {:ok, {:ok, %FlowState{} = transformed}} ->
-        {:ok, transformed}
-
-      {:ok, {:error, reason}} ->
-        {:error, callback_error(:transform_flow, reason)}
-
-      {:ok, other} ->
-        {:error,
-         invalid_callback_result(:transform_flow, "AshAi.Actions.Prompt.FlowState", other)}
-
-      {:error, error} ->
-        {:error, error}
+    defp resolve_model_spec(model, input, context) when is_function(model, 2) do
+      resolve_model_spec(model.(input, context), input, context)
     end
-  end
 
-  defp apply_transform_flow(_flow_state, transform_flow, _context) do
-    {:error, invalid_callback_option(:transform_flow, transform_flow)}
-  end
+    defp resolve_model_spec(model, input, context) when is_function(model, 1) do
+      resolve_model_spec(model.(input), input, context)
+    end
 
-  defp run_flow_callback(callback_name, fun) do
-    {:ok, fun.()}
-  rescue
-    error ->
-      {:error,
-       Ash.Error.Unknown.UnknownError.exception(
-         error:
-           "#{callback_name} callback raised: #{Exception.format(:error, error, __STACKTRACE__)}"
-       )}
-  end
+    defp resolve_model_spec(model, _input, _context) when is_function(model, 0) do
+      model.()
+    end
 
-  defp callback_error(callback_name, reason) do
-    Ash.Error.Unknown.UnknownError.exception(
-      error: "#{callback_name} callback returned error: #{inspect(reason)}"
-    )
-  end
+    defp resolve_model_spec(model, _input, _context), do: model
 
-  defp invalid_callback_result(callback_name, expected, result) do
-    Ash.Error.Unknown.UnknownError.exception(
-      error: """
-      #{callback_name} callback must return #{expected} (or {:ok, value}).
-      Got: #{inspect(result)}
-      """
-    )
-  end
+    defp build_flow_state(reqllm_context, model, req_llm_module, req_llm_opts, context, opts) do
+      %FlowState{
+        model: model,
+        req_llm: req_llm_module,
+        req_llm_opts: req_llm_opts,
+        messages: reqllm_context.messages,
+        tool_selection: Keyword.get(opts, :tools, false),
+        extra_tools: Keyword.get(opts, :extra_tools, []),
+        max_iterations: Keyword.get(opts, :max_iterations, :infinity),
+        strict: Keyword.get(opts, :strict, true),
+        verbose?: Keyword.get(opts, :verbose?, false),
+        on_tool_start: opts[:on_tool_start],
+        on_tool_end: opts[:on_tool_end],
+        actor: Map.get(context, :actor),
+        tenant: Map.get(context, :tenant),
+        source_context: Map.get(context, :source_context) || %{}
+      }
+    end
 
-  defp invalid_callback_option(callback_name, value) do
-    Ash.Error.Unknown.UnknownError.exception(
-      error: "#{callback_name} must be a 2-arity function, got: #{inspect(value)}"
-    )
-  end
+    defp apply_flow_customizations(flow_state, context, opts) do
+      apply_transform_flow(flow_state, opts[:transform_flow], context)
+    end
 
-  defp maybe_run_tools(flow_state, input, opts) do
-    if should_run_tool_loop?(flow_state) do
-      case prompt_loop_opts(flow_state.tool_selection, input, flow_state, opts) do
-        {:ok, loop_opts} ->
-          case AshAi.ToolLoop.run(flow_state.messages, loop_opts) do
-            {:ok, %AshAi.ToolLoop.Result{messages: messages}} ->
-              {:ok, ReqLLM.Context.new(messages)}
+    defp apply_transform_flow(flow_state, nil, _context), do: {:ok, flow_state}
 
-            {:error, reason} ->
-              if flow_state.verbose? do
-                Logger.debug(fn ->
-                  "AshAi.Actions.Prompt tool loop failed: #{inspect(reason)}"
-                end)
-              end
+    defp apply_transform_flow(flow_state, transform_flow, context)
+         when is_function(transform_flow, 2) do
+      case run_flow_callback(:transform_flow, fn -> transform_flow.(flow_state, context) end) do
+        {:ok, %FlowState{} = transformed} ->
+          {:ok, transformed}
 
-              {:error,
-               Ash.Error.Unknown.UnknownError.exception(
-                 error: "Tool loop failed in prompt action: #{inspect(reason)}"
-               )}
-          end
+        {:ok, {:ok, %FlowState{} = transformed}} ->
+          {:ok, transformed}
+
+        {:ok, {:error, reason}} ->
+          {:error, callback_error(:transform_flow, reason)}
+
+        {:ok, other} ->
+          {:error,
+           invalid_callback_result(:transform_flow, "AshAi.Actions.Prompt.FlowState", other)}
 
         {:error, error} ->
           {:error, error}
       end
-    else
-      {:ok, ReqLLM.Context.new(flow_state.messages)}
     end
-  end
 
-  defp prompt_loop_opts(tool_selection, input, flow_state, opts) do
-    domain = Ash.Resource.Info.domain(input.resource)
+    defp apply_transform_flow(_flow_state, transform_flow, _context) do
+      {:error, invalid_callback_option(:transform_flow, transform_flow)}
+    end
 
-    base_opts =
-      [
-        model: flow_state.model,
-        req_llm: flow_state.req_llm,
-        req_llm_opts: flow_state.req_llm_opts,
-        max_iterations: flow_state.max_iterations,
-        actor: flow_state.actor,
-        tenant: flow_state.tenant,
-        context: flow_state.source_context,
-        strict: flow_state.strict,
-        tools: tool_selection,
-        extra_tools: flow_state.extra_tools
-      ]
-      |> maybe_put_option(
-        :on_tool_start,
-        compose_callbacks(
-          verbose_tool_start_callback(flow_state.verbose?),
-          flow_state.on_tool_start
-        )
-      )
-      |> maybe_put_option(
-        :on_tool_end,
-        compose_callbacks(verbose_tool_end_callback(flow_state.verbose?), flow_state.on_tool_end)
-      )
-
-    cond do
-      needs_ash_tools?(tool_selection) == false ->
-        {:ok, base_opts}
-
-      Keyword.has_key?(opts, :actions) ->
-        {:ok, Keyword.put(base_opts, :actions, Keyword.fetch!(opts, :actions))}
-
-      Keyword.has_key?(opts, :otp_app) ->
-        {:ok, Keyword.put(base_opts, :otp_app, Keyword.fetch!(opts, :otp_app))}
-
-      domain ->
-        domain_actions =
-          domain
-          |> AshAi.Info.tools()
-          |> Enum.group_by(& &1.resource, & &1.action)
-          |> Map.to_list()
-
-        {:ok, Keyword.put(base_opts, :actions, domain_actions)}
-
-      true ->
+    defp run_flow_callback(callback_name, fun) do
+      {:ok, fun.()}
+    rescue
+      error ->
         {:error,
          Ash.Error.Unknown.UnknownError.exception(
-           error: """
-           Prompt action tool use requires either:
-           - `otp_app: :your_app`, or
-           - explicit `actions: [{Resource, [:action]}]`, or
-           - a resource with a resolvable Ash domain.
-           """
+           error:
+             "#{callback_name} callback raised: #{Exception.format(:error, error, __STACKTRACE__)}"
          )}
     end
-  end
 
-  defp should_run_tool_loop?(flow_state) do
-    needs_ash_tools?(flow_state.tool_selection) or flow_state.extra_tools != []
-  end
-
-  defp needs_ash_tools?(tool_selection) do
-    tool_selection == true or (is_list(tool_selection) and tool_selection != [])
-  end
-
-  defp build_json_schema(input) do
-    if input.action.returns do
-      inner_schema = return_inner_schema(input.action)
-
-      result_schema =
-        if input.action.allow_nil? do
-          %{"anyOf" => [%{"type" => "null"}, inner_schema]}
-        else
-          inner_schema
-        end
-
-      %{
-        "type" => "object",
-        "properties" => %{
-          "result" => result_schema
-        },
-        "required" => ["result"],
-        "additionalProperties" => false
-      }
-    else
-      %{
-        "type" => "object",
-        "properties" => %{
-          "result" => %{"type" => "null"}
-        },
-        "required" => ["result"],
-        "additionalProperties" => false
-      }
+    defp callback_error(callback_name, reason) do
+      Ash.Error.Unknown.UnknownError.exception(
+        error: "#{callback_name} callback returned error: #{inspect(reason)}"
+      )
     end
-  end
 
-  defp return_inner_schema(%{returns: :map} = action) do
-    if unconstrained_map_return?(action.constraints) do
-      %{"type" => "object"}
-    else
+    defp invalid_callback_result(callback_name, expected, result) do
+      Ash.Error.Unknown.UnknownError.exception(
+        error: """
+        #{callback_name} callback must return #{expected} (or {:ok, value}).
+        Got: #{inspect(result)}
+        """
+      )
+    end
+
+    defp invalid_callback_option(callback_name, value) do
+      Ash.Error.Unknown.UnknownError.exception(
+        error: "#{callback_name} must be a 2-arity function, got: #{inspect(value)}"
+      )
+    end
+
+    defp maybe_run_tools(flow_state, input, opts) do
+      if should_run_tool_loop?(flow_state) do
+        case prompt_loop_opts(flow_state.tool_selection, input, flow_state, opts) do
+          {:ok, loop_opts} ->
+            case AshAi.ToolLoop.run(flow_state.messages, loop_opts) do
+              {:ok, %AshAi.ToolLoop.Result{messages: messages}} ->
+                {:ok, ReqLLM.Context.new(messages)}
+
+              {:error, reason} ->
+                if flow_state.verbose? do
+                  Logger.debug(fn ->
+                    "AshAi.Actions.Prompt tool loop failed: #{inspect(reason)}"
+                  end)
+                end
+
+                {:error,
+                 Ash.Error.Unknown.UnknownError.exception(
+                   error: "Tool loop failed in prompt action: #{inspect(reason)}"
+                 )}
+            end
+
+          {:error, error} ->
+            {:error, error}
+        end
+      else
+        {:ok, ReqLLM.Context.new(flow_state.messages)}
+      end
+    end
+
+    defp prompt_loop_opts(tool_selection, input, flow_state, opts) do
+      domain = Ash.Resource.Info.domain(input.resource)
+
+      base_opts =
+        [
+          model: flow_state.model,
+          req_llm: flow_state.req_llm,
+          req_llm_opts: flow_state.req_llm_opts,
+          max_iterations: flow_state.max_iterations,
+          actor: flow_state.actor,
+          tenant: flow_state.tenant,
+          context: flow_state.source_context,
+          strict: flow_state.strict,
+          tools: tool_selection,
+          extra_tools: flow_state.extra_tools
+        ]
+        |> maybe_put_option(
+          :on_tool_start,
+          compose_callbacks(
+            verbose_tool_start_callback(flow_state.verbose?),
+            flow_state.on_tool_start
+          )
+        )
+        |> maybe_put_option(
+          :on_tool_end,
+          compose_callbacks(
+            verbose_tool_end_callback(flow_state.verbose?),
+            flow_state.on_tool_end
+          )
+        )
+
+      cond do
+        needs_ash_tools?(tool_selection) == false ->
+          {:ok, base_opts}
+
+        Keyword.has_key?(opts, :actions) ->
+          {:ok, Keyword.put(base_opts, :actions, Keyword.fetch!(opts, :actions))}
+
+        Keyword.has_key?(opts, :otp_app) ->
+          {:ok, Keyword.put(base_opts, :otp_app, Keyword.fetch!(opts, :otp_app))}
+
+        domain ->
+          domain_actions =
+            domain
+            |> AshAi.Info.tools()
+            |> Enum.group_by(& &1.resource, & &1.action)
+            |> Map.to_list()
+
+          {:ok, Keyword.put(base_opts, :actions, domain_actions)}
+
+        true ->
+          {:error,
+           Ash.Error.Unknown.UnknownError.exception(
+             error: """
+             Prompt action tool use requires either:
+             - `otp_app: :your_app`, or
+             - explicit `actions: [{Resource, [:action]}]`, or
+             - a resource with a resolvable Ash domain.
+             """
+           )}
+      end
+    end
+
+    defp should_run_tool_loop?(flow_state) do
+      needs_ash_tools?(flow_state.tool_selection) or flow_state.extra_tools != []
+    end
+
+    defp needs_ash_tools?(tool_selection) do
+      tool_selection == true or (is_list(tool_selection) and tool_selection != [])
+    end
+
+    defp build_json_schema(input) do
+      if input.action.returns do
+        inner_schema = return_inner_schema(input.action)
+
+        result_schema =
+          if input.action.allow_nil? do
+            %{"anyOf" => [%{"type" => "null"}, inner_schema]}
+          else
+            inner_schema
+          end
+
+        %{
+          "type" => "object",
+          "properties" => %{
+            "result" => result_schema
+          },
+          "required" => ["result"],
+          "additionalProperties" => false
+        }
+      else
+        %{
+          "type" => "object",
+          "properties" => %{
+            "result" => %{"type" => "null"}
+          },
+          "required" => ["result"],
+          "additionalProperties" => false
+        }
+      end
+    end
+
+    defp return_inner_schema(%{returns: :map} = action) do
+      if unconstrained_map_return?(action.constraints) do
+        %{"type" => "object"}
+      else
+        AshAi.OpenApi.resource_write_attribute_type(
+          %{name: :result, type: action.returns, constraints: action.constraints},
+          nil,
+          :create
+        )
+      end
+    end
+
+    defp return_inner_schema(action) do
       AshAi.OpenApi.resource_write_attribute_type(
         %{name: :result, type: action.returns, constraints: action.constraints},
         nil,
         :create
       )
     end
-  end
 
-  defp return_inner_schema(action) do
-    AshAi.OpenApi.resource_write_attribute_type(
-      %{name: :result, type: action.returns, constraints: action.constraints},
-      nil,
-      :create
-    )
-  end
-
-  defp unconstrained_map_return?(constraints) when is_list(constraints) do
-    Keyword.get(constraints, :fields) in [nil, []]
-  end
-
-  defp unconstrained_map_return?(constraints) when is_map(constraints) do
-    Map.get(constraints, :fields) in [nil, []]
-  end
-
-  defp unconstrained_map_return?(_), do: true
-
-  defp compose_callbacks(nil, nil), do: nil
-  defp compose_callbacks(callback, nil) when is_function(callback, 1), do: callback
-  defp compose_callbacks(nil, callback) when is_function(callback, 1), do: callback
-
-  defp compose_callbacks(first, second) when is_function(first, 1) and is_function(second, 1) do
-    fn event ->
-      first.(event)
-      second.(event)
+    defp unconstrained_map_return?(constraints) when is_list(constraints) do
+      Keyword.get(constraints, :fields) in [nil, []]
     end
-  end
 
-  defp verbose_tool_start_callback(false), do: nil
-
-  defp verbose_tool_start_callback(true) do
-    fn event ->
-      Logger.debug(fn ->
-        "AshAi.Actions.Prompt tool start tool=#{event.tool_name} action=#{event.action} arguments=#{inspect(event.arguments)}"
-      end)
+    defp unconstrained_map_return?(constraints) when is_map(constraints) do
+      Map.get(constraints, :fields) in [nil, []]
     end
-  end
 
-  defp verbose_tool_end_callback(false), do: nil
+    defp unconstrained_map_return?(_), do: true
 
-  defp verbose_tool_end_callback(true) do
-    fn event ->
-      Logger.debug(fn ->
-        "AshAi.Actions.Prompt tool end tool=#{event.tool_name} result=#{inspect(event.result)}"
-      end)
+    defp compose_callbacks(nil, nil), do: nil
+    defp compose_callbacks(callback, nil) when is_function(callback, 1), do: callback
+    defp compose_callbacks(nil, callback) when is_function(callback, 1), do: callback
+
+    defp compose_callbacks(first, second) when is_function(first, 1) and is_function(second, 1) do
+      fn event ->
+        first.(event)
+        second.(event)
+      end
     end
-  end
 
-  defp maybe_put_option(opts, _key, nil), do: opts
-  defp maybe_put_option(opts, key, value), do: Keyword.put(opts, key, value)
+    defp verbose_tool_start_callback(false), do: nil
 
-  defp cast_result(result, %{returns: nil}) do
-    case unwrap_result(result) do
-      nil ->
-        :ok
-
-      value ->
-        {:error, "Failed to cast LLM response: expected nil return, got: #{inspect(value)}"}
+    defp verbose_tool_start_callback(true) do
+      fn event ->
+        Logger.debug(fn ->
+          "AshAi.Actions.Prompt tool start tool=#{event.tool_name} action=#{event.action} arguments=#{inspect(event.arguments)}"
+        end)
+      end
     end
-  end
 
-  defp cast_result(result, action) do
-    value = unwrap_result(result)
+    defp verbose_tool_end_callback(false), do: nil
 
-    with {:ok, value} <-
-           Ash.Type.cast_input(
-             action.returns,
-             value,
-             action.constraints
-           ),
-         {:ok, value} <-
-           Ash.Type.apply_constraints(
-             action.returns,
-             value,
-             action.constraints
-           ) do
-      {:ok, value}
-    else
-      {:error, error} ->
-        {:error, "Failed to cast LLM response: #{inspect(error)}. Response: #{inspect(result)}"}
+    defp verbose_tool_end_callback(true) do
+      fn event ->
+        Logger.debug(fn ->
+          "AshAi.Actions.Prompt tool end tool=#{event.tool_name} result=#{inspect(event.result)}"
+        end)
+      end
     end
-  end
 
-  defp unwrap_result(%{"result" => value}), do: value
-  defp unwrap_result(%{result: value}), do: value
-  defp unwrap_result(value), do: value
+    defp maybe_put_option(opts, _key, nil), do: opts
+    defp maybe_put_option(opts, key, value), do: Keyword.put(opts, key, value)
 
-  # sobelow_skip ["RCE.EEx"]
-  defp build_context(input, opts, context) do
-    prompt = Keyword.get(opts, :prompt, @prompt_template)
+    defp cast_result(result, %{returns: nil}) do
+      case unwrap_result(result) do
+        nil ->
+          :ok
 
-    prompt_value =
+        value ->
+          {:error, "Failed to cast LLM response: expected nil return, got: #{inspect(value)}"}
+      end
+    end
+
+    defp cast_result(result, action) do
+      value = unwrap_result(result)
+
+      with {:ok, value} <-
+             Ash.Type.cast_input(
+               action.returns,
+               value,
+               action.constraints
+             ),
+           {:ok, value} <-
+             Ash.Type.apply_constraints(
+               action.returns,
+               value,
+               action.constraints
+             ) do
+        {:ok, value}
+      else
+        {:error, error} ->
+          {:error, "Failed to cast LLM response: #{inspect(error)}. Response: #{inspect(result)}"}
+      end
+    end
+
+    defp unwrap_result(%{"result" => value}), do: value
+    defp unwrap_result(%{result: value}), do: value
+    defp unwrap_result(value), do: value
+
+    # sobelow_skip ["RCE.EEx"]
+    defp build_context(input, opts, context) do
+      prompt = Keyword.get(opts, :prompt, @prompt_template)
+
+      prompt_value =
+        case prompt do
+          func when is_function(func, 2) ->
+            func.(input, context)
+
+          other ->
+            other
+        end
+
+      normalize_to_context(prompt_value, input, context)
+    end
+
+    # sobelow_skip ["RCE.EEx"]
+    defp normalize_to_context(prompt, input, context) do
       case prompt do
-        func when is_function(func, 2) ->
-          func.(input, context)
+        # Already a ReqLLM.Context - pass through
+        %ReqLLM.Context{} = ctx ->
+          ctx
 
-        other ->
-          other
+        # String template - evaluate and create system + user messages
+        prompt when is_binary(prompt) ->
+          system_prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
+
+          ReqLLM.Context.new([
+            ReqLLM.Context.system(system_prompt),
+            ReqLLM.Context.user("Perform the action")
+          ])
+
+        # {system, user} tuple - evaluate both templates
+        {system, user} when is_binary(system) and is_binary(user) ->
+          system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
+          user_message = EEx.eval_string(user, assigns: [input: input, context: context])
+
+          ReqLLM.Context.new([
+            ReqLLM.Context.system(system_prompt),
+            ReqLLM.Context.user(user_message)
+          ])
+
+        # List of messages - process EEx templates in string content, then normalize
+        messages when is_list(messages) ->
+          processed = process_message_templates(messages, input, context)
+          ReqLLM.Context.normalize!(processed, convert_loose: true)
       end
+    end
 
-    normalize_to_context(prompt_value, input, context)
-  end
+    # sobelow_skip ["RCE.EEx"]
+    defp process_message_templates(messages, input, context) do
+      Enum.map(messages, fn msg ->
+        case msg do
+          # ReqLLM.Message struct - process content if it's a string
+          %ReqLLM.Message{content: content} = message when is_binary(content) ->
+            processed = EEx.eval_string(content, assigns: [input: input, context: context])
+            %{message | content: processed}
 
-  # sobelow_skip ["RCE.EEx"]
-  defp normalize_to_context(prompt, input, context) do
-    case prompt do
-      # Already a ReqLLM.Context - pass through
-      %ReqLLM.Context{} = ctx ->
-        ctx
+          %ReqLLM.Message{} = message ->
+            message
 
-      # String template - evaluate and create system + user messages
-      prompt when is_binary(prompt) ->
-        system_prompt = EEx.eval_string(prompt, assigns: [input: input, context: context])
+          # Loose map with string keys
+          %{"content" => content} = map when is_binary(content) ->
+            processed = EEx.eval_string(content, assigns: [input: input, context: context])
+            Map.put(map, "content", processed)
 
-        ReqLLM.Context.new([
-          ReqLLM.Context.system(system_prompt),
-          ReqLLM.Context.user("Perform the action")
-        ])
+          # Loose map with atom keys
+          %{content: content} = map when is_binary(content) ->
+            processed = EEx.eval_string(content, assigns: [input: input, context: context])
+            Map.put(map, :content, processed)
 
-      # {system, user} tuple - evaluate both templates
-      {system, user} when is_binary(system) and is_binary(user) ->
-        system_prompt = EEx.eval_string(system, assigns: [input: input, context: context])
-        user_message = EEx.eval_string(user, assigns: [input: input, context: context])
-
-        ReqLLM.Context.new([
-          ReqLLM.Context.system(system_prompt),
-          ReqLLM.Context.user(user_message)
-        ])
-
-      # List of messages - process EEx templates in string content, then normalize
-      messages when is_list(messages) ->
-        processed = process_message_templates(messages, input, context)
-        ReqLLM.Context.normalize!(processed, convert_loose: true)
+          # Pass through anything else (ReqLLM.Context.normalize will handle it)
+          other ->
+            other
+        end
+      end)
     end
   end
+else
+  defmodule AshAi.Actions.Prompt do
+    @moduledoc "Requires the `req_llm` dependency."
 
-  # sobelow_skip ["RCE.EEx"]
-  defp process_message_templates(messages, input, context) do
-    Enum.map(messages, fn msg ->
-      case msg do
-        # ReqLLM.Message struct - process content if it's a string
-        %ReqLLM.Message{content: content} = message when is_binary(content) ->
-          processed = EEx.eval_string(content, assigns: [input: input, context: context])
-          %{message | content: processed}
+    use Ash.Resource.Actions.Implementation
 
-        %ReqLLM.Message{} = message ->
-          message
-
-        # Loose map with string keys
-        %{"content" => content} = map when is_binary(content) ->
-          processed = EEx.eval_string(content, assigns: [input: input, context: context])
-          Map.put(map, "content", processed)
-
-        # Loose map with atom keys
-        %{content: content} = map when is_binary(content) ->
-          processed = EEx.eval_string(content, assigns: [input: input, context: context])
-          Map.put(map, :content, processed)
-
-        # Pass through anything else (ReqLLM.Context.normalize will handle it)
-        other ->
-          other
-      end
-    end)
+    @impl true
+    def run(_input, _opts, _context),
+      do: AshAi.Dependencies.require_req_llm!("`AshAi.Actions.Prompt`")
   end
 end

--- a/lib/ash_ai/chat_ui/tools.ex
+++ b/lib/ash_ai/chat_ui/tools.ex
@@ -2,249 +2,259 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAi.ChatUI.Tools do
-  @moduledoc """
-  Normalizes tool call and tool result data for generated chat UIs.
+if Code.ensure_loaded?(ReqLLM) do
+  defmodule AshAi.ChatUI.Tools do
+    @moduledoc """
+    Normalizes tool call and tool result data for generated chat UIs.
 
-  `mix ash_ai.gen.chat` templates delegate to `extract/1` so the generated modules
-  stay small and the parsing behavior is centralized in AshAi.
+    `mix ash_ai.gen.chat` templates delegate to `extract/1` so the generated modules
+    stay small and the parsing behavior is centralized in AshAi.
 
-  Advanced apps can override the generated delegation seam:
+    Advanced apps can override the generated delegation seam:
 
-      @chat_ui_tools MyApp.ChatUITools
-  """
+        @chat_ui_tools MyApp.ChatUITools
+    """
 
-  alias Ash.Error.Unknown.UnknownError
+    alias Ash.Error.Unknown.UnknownError
 
-  @type tool_call :: %{
-          required(:id) => String.t(),
-          required(:name) => String.t(),
-          required(:arguments) => map(),
-          required(:arguments_preview) => String.t()
-        }
+    @type tool_call :: %{
+            required(:id) => String.t(),
+            required(:name) => String.t(),
+            required(:arguments) => map(),
+            required(:arguments_preview) => String.t()
+          }
 
-  @type tool_result :: %{
-          required(:id) => String.t(),
-          required(:name) => String.t() | nil,
-          required(:content) => term(),
-          required(:is_error) => boolean(),
-          required(:content_preview) => String.t()
-        }
+    @type tool_result :: %{
+            required(:id) => String.t(),
+            required(:name) => String.t() | nil,
+            required(:content) => term(),
+            required(:is_error) => boolean(),
+            required(:content_preview) => String.t()
+          }
 
-  @type extracted_tool_data :: %{
-          required(:tool_calls) => [tool_call()],
-          required(:tool_results) => [tool_result()]
-        }
+    @type extracted_tool_data :: %{
+            required(:tool_calls) => [tool_call()],
+            required(:tool_results) => [tool_result()]
+          }
 
-  @spec extract(map() | struct()) :: {:ok, extracted_tool_data()} | {:error, Ash.Error.t()}
-  def extract(message) when is_map(message) do
-    with {:ok, raw_tool_calls} <- fetch_list_field(message, :tool_calls),
-         {:ok, raw_tool_results} <- fetch_list_field(message, :tool_results) do
-      tool_calls = normalize_tool_calls(raw_tool_calls)
-      calls_by_id = Map.new(tool_calls, fn call -> {call.id, call.name} end)
-      tool_results = normalize_tool_results(raw_tool_results, calls_by_id)
+    @spec extract(map() | struct()) :: {:ok, extracted_tool_data()} | {:error, Ash.Error.t()}
+    def extract(message) when is_map(message) do
+      with {:ok, raw_tool_calls} <- fetch_list_field(message, :tool_calls),
+           {:ok, raw_tool_results} <- fetch_list_field(message, :tool_results) do
+        tool_calls = normalize_tool_calls(raw_tool_calls)
+        calls_by_id = Map.new(tool_calls, fn call -> {call.id, call.name} end)
+        tool_results = normalize_tool_results(raw_tool_results, calls_by_id)
 
-      {:ok, %{tool_calls: tool_calls, tool_results: tool_results}}
+        {:ok, %{tool_calls: tool_calls, tool_results: tool_results}}
+      end
     end
-  end
 
-  def extract(message) do
-    {:error, invalid_payload_error("message", message, "a map or struct")}
-  end
-
-  defp fetch_list_field(message, field) do
-    case map_field(message, field) do
-      nil ->
-        {:ok, []}
-
-      value when is_list(value) ->
-        {:ok, value}
-
-      value ->
-        {:error, invalid_payload_error(Atom.to_string(field), value, "a list or nil")}
+    def extract(message) do
+      {:error, invalid_payload_error("message", message, "a map or struct")}
     end
-  end
 
-  defp normalize_tool_calls(tool_calls) when is_list(tool_calls) do
-    Enum.flat_map(tool_calls, fn
-      call when is_map(call) ->
-        case normalize_tool_call(call) do
-          nil -> []
-          normalized -> [normalized]
-        end
+    defp fetch_list_field(message, field) do
+      case map_field(message, field) do
+        nil ->
+          {:ok, []}
 
-      _ ->
-        []
-    end)
-  end
+        value when is_list(value) ->
+          {:ok, value}
 
-  defp normalize_tool_call(call) when is_map(call) do
-    req_llm_call = safe_req_llm_tool_call_from_map(call)
-    id = req_llm_call[:id] || map_field(call, :id) || map_field(call, :call_id)
-
-    name =
-      req_llm_call[:name] || map_field(call, :name) ||
-        map_field(map_field(call, :function), :name)
-
-    arguments =
-      req_llm_call[:arguments]
-      |> normalize_tool_call_arguments(call)
-
-    if is_binary(name) do
-      %{
-        id: if(is_binary(id), do: id, else: "call_unknown"),
-        name: name,
-        arguments: arguments,
-        arguments_preview: tool_call_arguments_preview(arguments)
-      }
+        value ->
+          {:error, invalid_payload_error(Atom.to_string(field), value, "a list or nil")}
+      end
     end
-  end
 
-  defp safe_req_llm_tool_call_from_map(call) do
-    ReqLLM.ToolCall.from_map(call)
-  rescue
-    _ -> %{}
-  end
+    defp normalize_tool_calls(tool_calls) when is_list(tool_calls) do
+      Enum.flat_map(tool_calls, fn
+        call when is_map(call) ->
+          case normalize_tool_call(call) do
+            nil -> []
+            normalized -> [normalized]
+          end
 
-  defp normalize_tool_call_arguments(nil, call) do
-    call
-    |> call_arguments()
-    |> normalize_raw_tool_call_arguments()
-  end
+        _ ->
+          []
+      end)
+    end
 
-  defp normalize_tool_call_arguments(arguments, call) when is_map(arguments) do
-    if arguments == %{} do
+    defp normalize_tool_call(call) when is_map(call) do
+      req_llm_call = safe_req_llm_tool_call_from_map(call)
+      id = req_llm_call[:id] || map_field(call, :id) || map_field(call, :call_id)
+
+      name =
+        req_llm_call[:name] || map_field(call, :name) ||
+          map_field(map_field(call, :function), :name)
+
+      arguments =
+        req_llm_call[:arguments]
+        |> normalize_tool_call_arguments(call)
+
+      if is_binary(name) do
+        %{
+          id: if(is_binary(id), do: id, else: "call_unknown"),
+          name: name,
+          arguments: arguments,
+          arguments_preview: tool_call_arguments_preview(arguments)
+        }
+      end
+    end
+
+    defp safe_req_llm_tool_call_from_map(call) do
+      ReqLLM.ToolCall.from_map(call)
+    rescue
+      _ -> %{}
+    end
+
+    defp normalize_tool_call_arguments(nil, call) do
       call
       |> call_arguments()
       |> normalize_raw_tool_call_arguments()
-    else
+    end
+
+    defp normalize_tool_call_arguments(arguments, call) when is_map(arguments) do
+      if arguments == %{} do
+        call
+        |> call_arguments()
+        |> normalize_raw_tool_call_arguments()
+      else
+        arguments
+      end
+    end
+
+    defp normalize_tool_call_arguments(arguments, _call),
+      do: normalize_raw_tool_call_arguments(arguments)
+
+    defp call_arguments(call) do
+      map_field(call, :arguments) ||
+        call
+        |> map_field(:function)
+        |> map_field(:arguments)
+    end
+
+    defp normalize_raw_tool_call_arguments(nil), do: %{}
+    defp normalize_raw_tool_call_arguments(arguments) when is_map(arguments), do: arguments
+
+    defp normalize_raw_tool_call_arguments(arguments) when is_binary(arguments) do
+      case Jason.decode(arguments) do
+        {:ok, decoded} when is_map(decoded) -> decoded
+        _ -> %{"raw" => arguments}
+      end
+    end
+
+    defp normalize_raw_tool_call_arguments(arguments), do: %{"raw" => inspect(arguments)}
+
+    defp tool_call_arguments_preview(arguments) do
       arguments
+      |> safe_json_encode()
+      |> String.slice(0, 80)
     end
-  end
 
-  defp normalize_tool_call_arguments(arguments, _call),
-    do: normalize_raw_tool_call_arguments(arguments)
+    defp normalize_tool_results(tool_results, calls_by_id) when is_list(tool_results) do
+      Enum.flat_map(tool_results, fn
+        result when is_map(result) ->
+          case normalize_tool_result(result, calls_by_id) do
+            nil -> []
+            normalized -> [normalized]
+          end
 
-  defp call_arguments(call) do
-    map_field(call, :arguments) ||
-      call
-      |> map_field(:function)
-      |> map_field(:arguments)
-  end
-
-  defp normalize_raw_tool_call_arguments(nil), do: %{}
-  defp normalize_raw_tool_call_arguments(arguments) when is_map(arguments), do: arguments
-
-  defp normalize_raw_tool_call_arguments(arguments) when is_binary(arguments) do
-    case Jason.decode(arguments) do
-      {:ok, decoded} when is_map(decoded) -> decoded
-      _ -> %{"raw" => arguments}
+        _ ->
+          []
+      end)
     end
-  end
 
-  defp normalize_raw_tool_call_arguments(arguments), do: %{"raw" => inspect(arguments)}
+    defp normalize_tool_result(result, calls_by_id) when is_map(result) do
+      id =
+        map_field(result, :tool_call_id) || map_field(result, :id) || map_field(result, :call_id)
 
-  defp tool_call_arguments_preview(arguments) do
-    arguments
-    |> safe_json_encode()
-    |> String.slice(0, 80)
-  end
+      name = map_field(result, :name)
+      content = map_field(result, :content)
 
-  defp normalize_tool_results(tool_results, calls_by_id) when is_list(tool_results) do
-    Enum.flat_map(tool_results, fn
-      result when is_map(result) ->
-        case normalize_tool_result(result, calls_by_id) do
-          nil -> []
-          normalized -> [normalized]
-        end
-
-      _ ->
-        []
-    end)
-  end
-
-  defp normalize_tool_result(result, calls_by_id) when is_map(result) do
-    id = map_field(result, :tool_call_id) || map_field(result, :id) || map_field(result, :call_id)
-    name = map_field(result, :name)
-    content = map_field(result, :content)
-
-    if is_binary(id) || not is_nil(content) do
-      %{
-        id: if(is_binary(id), do: id, else: "tool_result"),
-        name:
-          if(is_binary(name),
-            do: name,
-            else: if(is_binary(id), do: Map.get(calls_by_id, id), else: nil)
-          ),
-        content: content,
-        is_error: normalize_is_error(map_field(result, :is_error)),
-        content_preview: tool_result_preview(content)
-      }
+      if is_binary(id) || not is_nil(content) do
+        %{
+          id: if(is_binary(id), do: id, else: "tool_result"),
+          name:
+            if(is_binary(name),
+              do: name,
+              else: if(is_binary(id), do: Map.get(calls_by_id, id), else: nil)
+            ),
+          content: content,
+          is_error: normalize_is_error(map_field(result, :is_error)),
+          content_preview: tool_result_preview(content)
+        }
+      end
     end
-  end
 
-  defp normalize_is_error(true), do: true
-  defp normalize_is_error("true"), do: true
-  defp normalize_is_error(_), do: false
+    defp normalize_is_error(true), do: true
+    defp normalize_is_error("true"), do: true
+    defp normalize_is_error(_), do: false
 
-  defp tool_result_preview(content) do
-    content
-    |> normalize_text_content()
-    |> String.replace(~r/\s+/, " ")
-    |> String.trim()
-    |> String.slice(0, 180)
-  end
-
-  defp normalize_text_content(nil), do: ""
-
-  defp normalize_text_content(content) when is_binary(content) do
-    case Jason.decode(content) do
-      {:ok, decoded} -> normalize_text_content(decoded)
-      {:error, _} -> content
+    defp tool_result_preview(content) do
+      content
+      |> normalize_text_content()
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
+      |> String.slice(0, 180)
     end
-  end
 
-  defp normalize_text_content(content) when is_map(content) or is_list(content) do
-    safe_json_encode(content)
-  end
+    defp normalize_text_content(nil), do: ""
 
-  defp normalize_text_content(content), do: inspect(content)
-
-  defp safe_json_encode(content) do
-    case Jason.encode(content) do
-      {:ok, encoded} -> encoded
-      {:error, _} -> inspect(content)
+    defp normalize_text_content(content) when is_binary(content) do
+      case Jason.decode(content) do
+        {:ok, decoded} -> normalize_text_content(decoded)
+        {:error, _} -> content
+      end
     end
-  end
 
-  defp map_field(message, key) when is_map(message) do
-    case message do
-      %{^key => value} ->
-        value
-
-      %{} ->
-        Map.get(message, Atom.to_string(key))
+    defp normalize_text_content(content) when is_map(content) or is_list(content) do
+      safe_json_encode(content)
     end
-  end
 
-  defp map_field(_message, _key), do: nil
+    defp normalize_text_content(content), do: inspect(content)
 
-  defp invalid_payload_error(field, value, expected) do
-    Ash.Error.to_error_class(
-      UnknownError.exception(
-        error: "Invalid #{field}: expected #{expected}, got #{inspect(value_type(value))}"
+    defp safe_json_encode(content) do
+      case Jason.encode(content) do
+        {:ok, encoded} -> encoded
+        {:error, _} -> inspect(content)
+      end
+    end
+
+    defp map_field(message, key) when is_map(message) do
+      case message do
+        %{^key => value} ->
+          value
+
+        %{} ->
+          Map.get(message, Atom.to_string(key))
+      end
+    end
+
+    defp map_field(_message, _key), do: nil
+
+    defp invalid_payload_error(field, value, expected) do
+      Ash.Error.to_error_class(
+        UnknownError.exception(
+          error: "Invalid #{field}: expected #{expected}, got #{inspect(value_type(value))}"
+        )
       )
-    )
-  end
+    end
 
-  defp value_type(value) when is_map(value) and not is_struct(value), do: :map
-  defp value_type(value) when is_map(value), do: {:struct, value.__struct__}
-  defp value_type(value) when is_list(value), do: :list
-  defp value_type(value) when is_binary(value), do: :binary
-  defp value_type(value) when is_boolean(value), do: :boolean
-  defp value_type(value) when is_integer(value), do: :integer
-  defp value_type(value) when is_float(value), do: :float
-  defp value_type(nil), do: nil
-  defp value_type(value) when is_atom(value), do: :atom
-  defp value_type(_value), do: :term
+    defp value_type(value) when is_map(value) and not is_struct(value), do: :map
+    defp value_type(value) when is_map(value), do: {:struct, value.__struct__}
+    defp value_type(value) when is_list(value), do: :list
+    defp value_type(value) when is_binary(value), do: :binary
+    defp value_type(value) when is_boolean(value), do: :boolean
+    defp value_type(value) when is_integer(value), do: :integer
+    defp value_type(value) when is_float(value), do: :float
+    defp value_type(nil), do: nil
+    defp value_type(value) when is_atom(value), do: :atom
+    defp value_type(_value), do: :term
+  end
+else
+  defmodule AshAi.ChatUI.Tools do
+    @moduledoc "Requires the `req_llm` dependency."
+
+    def extract(_message), do: AshAi.Dependencies.require_req_llm!("`AshAi.ChatUI.Tools`")
+  end
 end

--- a/lib/ash_ai/dependencies.ex
+++ b/lib/ash_ai/dependencies.ex
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAi.Dependencies do
+  @moduledoc false
+
+  # `req_llm` is optional. It is only required for features that talk to an
+  # LLM; serving tools over MCP works without it.
+
+  @spec require_req_llm!(String.t()) :: no_return()
+  def require_req_llm!(feature) do
+    raise RuntimeError, """
+    #{feature} requires the `req_llm` dependency, which is optional in `ash_ai`.
+
+    Add it to your `mix.exs`:
+
+        {:req_llm, "~> 1.7"}
+
+    then run:
+
+        mix deps.get
+        mix deps.compile ash_ai --force
+    """
+  end
+end

--- a/lib/ash_ai/embedding_models/req_llm.ex
+++ b/lib/ash_ai/embedding_models/req_llm.ex
@@ -2,74 +2,90 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAi.EmbeddingModels.ReqLLM do
-  @moduledoc """
-  ReqLLM-backed embedding model for AshAi vectorization.
+if Code.ensure_loaded?(ReqLLM) do
+  defmodule AshAi.EmbeddingModels.ReqLLM do
+    @moduledoc """
+    ReqLLM-backed embedding model for AshAi vectorization.
 
-  Uses `ReqLLM.embed/2` to generate embeddings from text.
+    Uses `ReqLLM.embed/2` to generate embeddings from text.
 
-  ## Configuration
+    ## Configuration
 
-      vectorize do
-        embedding_model {AshAi.EmbeddingModels.ReqLLM,
-          model: "openai:text-embedding-3-small",
-          dimensions: 1536
-        }
-      end
+        vectorize do
+          embedding_model {AshAi.EmbeddingModels.ReqLLM,
+            model: "openai:text-embedding-3-small",
+            dimensions: 1536
+          }
+        end
 
-  ## Options
+    ## Options
 
-  - `:model` (required) - ReqLLM model identifier (e.g., "openai:text-embedding-3-small")
-  - `:dimensions` (required) - Vector dimensions for the model
-  - `:req_opts` (optional) - Additional options passed to ReqLLM
-  - `:max_batch_size` (optional) - Maximum batch size for chunking (default: 100)
+    - `:model` (required) - ReqLLM model identifier (e.g., "openai:text-embedding-3-small")
+    - `:dimensions` (required) - Vector dimensions for the model
+    - `:req_opts` (optional) - Additional options passed to ReqLLM
+    - `:max_batch_size` (optional) - Maximum batch size for chunking (default: 100)
 
-  ## Common Dimensions
+    ## Common Dimensions
 
-  - OpenAI text-embedding-3-small: 1536
-  - OpenAI text-embedding-3-large: 3072
-  - Google Gemini text-embedding-004: 768 or 3072
-  - Cohere embed-english-v3.0: 1024
-  - Voyage voyage-2: 1024
-  """
-  use AshAi.EmbeddingModel
+    - OpenAI text-embedding-3-small: 1536
+    - OpenAI text-embedding-3-large: 3072
+    - Google Gemini text-embedding-004: 768 or 3072
+    - Cohere embed-english-v3.0: 1024
+    - Voyage voyage-2: 1024
+    """
+    use AshAi.EmbeddingModel
 
-  @default_max_batch_size 100
+    @default_max_batch_size 100
 
-  @impl true
-  def dimensions(opts) do
-    Keyword.fetch!(opts, :dimensions)
-  end
-
-  @impl true
-  def generate(texts, opts) do
-    model = Keyword.fetch!(opts, :model)
-    req_opts = Keyword.get(opts, :req_opts, [])
-    max_batch_size = Keyword.get(opts, :max_batch_size, @default_max_batch_size)
-
-    inputs = Enum.map(texts, &(&1 || ""))
-
-    chunks = Enum.chunk_every(inputs, max_batch_size)
-
-    chunks
-    |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
-      case call_reqllm(model, chunk, req_opts) do
-        {:ok, embeddings} -> {:cont, {:ok, acc ++ embeddings}}
-        {:error, error} -> {:halt, {:error, error}}
-      end
-    end)
-  end
-
-  defp call_reqllm(model, inputs, req_opts) do
-    case ReqLLM.embed(model, inputs, req_opts) do
-      {:ok, embeddings} when is_list(embeddings) ->
-        {:ok, embeddings}
-
-      {:error, error} ->
-        {:error, error}
-
-      other ->
-        {:error, "Unexpected response from ReqLLM.embed/2: #{inspect(other)}"}
+    @impl true
+    def dimensions(opts) do
+      Keyword.fetch!(opts, :dimensions)
     end
+
+    @impl true
+    def generate(texts, opts) do
+      model = Keyword.fetch!(opts, :model)
+      req_opts = Keyword.get(opts, :req_opts, [])
+      max_batch_size = Keyword.get(opts, :max_batch_size, @default_max_batch_size)
+
+      inputs = Enum.map(texts, &(&1 || ""))
+
+      chunks = Enum.chunk_every(inputs, max_batch_size)
+
+      chunks
+      |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
+        case call_reqllm(model, chunk, req_opts) do
+          {:ok, embeddings} -> {:cont, {:ok, acc ++ embeddings}}
+          {:error, error} -> {:halt, {:error, error}}
+        end
+      end)
+    end
+
+    defp call_reqllm(model, inputs, req_opts) do
+      case ReqLLM.embed(model, inputs, req_opts) do
+        {:ok, embeddings} when is_list(embeddings) ->
+          {:ok, embeddings}
+
+        {:error, error} ->
+          {:error, error}
+
+        other ->
+          {:error, "Unexpected response from ReqLLM.embed/2: #{inspect(other)}"}
+      end
+    end
+  end
+else
+  defmodule AshAi.EmbeddingModels.ReqLLM do
+    @moduledoc "Requires the `req_llm` dependency."
+
+    use AshAi.EmbeddingModel
+
+    @impl true
+    def dimensions(_opts),
+      do: AshAi.Dependencies.require_req_llm!("`AshAi.EmbeddingModels.ReqLLM`")
+
+    @impl true
+    def generate(_texts, _opts),
+      do: AshAi.Dependencies.require_req_llm!("`AshAi.EmbeddingModels.ReqLLM`")
   end
 end

--- a/lib/ash_ai/mcp/server.ex
+++ b/lib/ash_ai/mcp/server.ex
@@ -942,13 +942,11 @@ defmodule AshAi.Mcp.Server do
     |> Enum.map(fn %Tool{} = tool ->
       # MCP schemas are advisory (no grammar-constrained sampling), so the
       # OpenAI strict transformation defaults off here.
-      {req_tool, _callback} =
-        AshAi.Tools.build(tool, strict: Keyword.get(opts, :strict, false))
-
       result = %{
-        "name" => req_tool.name,
-        "description" => req_tool.description,
-        "inputSchema" => req_tool.parameter_schema
+        "name" => to_string(tool.name),
+        "description" => AshAi.Tools.description(tool),
+        "inputSchema" =>
+          AshAi.Tools.parameter_schema(tool, strict: Keyword.get(opts, :strict, false))
       }
 
       if Tool.has_meta?(tool) do

--- a/lib/ash_ai/tool/builder.ex
+++ b/lib/ash_ai/tool/builder.ex
@@ -2,83 +2,88 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAi.Tool.Builder do
-  @moduledoc """
-  Builds ReqLLM.Tool structs and callbacks from AshAi.Tool DSL entities.
+if Code.ensure_loaded?(ReqLLM) do
+  defmodule AshAi.Tool.Builder do
+    @moduledoc """
+    Builds ReqLLM.Tool structs and callbacks from AshAi.Tool DSL entities.
 
-  This module is responsible for converting AshAi tool definitions into
-  the format expected by ReqLLM, including generating the parameter schema
-  and creating the callback function that executes the tool.
-  """
+    This module is responsible for converting AshAi tool definitions into
+    the format expected by ReqLLM, including generating the parameter schema
+    and creating the callback function that executes the tool.
+    """
 
-  alias AshAi.Tool.Execution
-  alias AshAi.Tool.Schema
-  alias AshAi.ToolEndEvent
-  alias AshAi.ToolStartEvent
+    alias AshAi.Tool.Execution
+    alias AshAi.Tool.Schema
+    alias AshAi.ToolEndEvent
+    alias AshAi.ToolStartEvent
 
-  @doc """
-  Builds a ReqLLM.Tool struct and callback function from an AshAi.Tool definition.
+    @doc """
+    Builds a ReqLLM.Tool struct and callback function from an AshAi.Tool definition.
 
-  Returns a tuple of `{ReqLLM.Tool, callback_fn}` where:
-  - `ReqLLM.Tool` contains the tool schema for the LLM
-  - `callback_fn` is a function/2 that takes (arguments, context) and executes the Ash action
+    Returns a tuple of `{ReqLLM.Tool, callback_fn}` where:
+    - `ReqLLM.Tool` contains the tool schema for the LLM
+    - `callback_fn` is a function/2 that takes (arguments, context) and executes the Ash action
 
-  ## Example
+    ## Example
 
-      {tool, callback} = AshAi.Tool.Builder.build(tool_def)
-      result = callback.(%{"input" => %{"name" => "foo"}}, %{actor: current_user})
-  """
-  def build(%AshAi.Tool{} = tool_def, opts \\ []) do
-    name = to_string(tool_def.name)
-    strict? = Keyword.get(opts, :strict, true)
+        {tool, callback} = AshAi.Tool.Builder.build(tool_def)
+        result = callback.(%{"input" => %{"name" => "foo"}}, %{actor: current_user})
+    """
+    def build(%AshAi.Tool{} = tool_def, opts \\ []) do
+      name = to_string(tool_def.name)
+      strict? = Keyword.get(opts, :strict, true)
 
-    description =
-      String.trim(
-        tool_def.description || tool_def.action.description ||
-          "Call the #{tool_def.action.name} tool"
-      )
+      description = AshAi.Tools.description(tool_def)
 
-    parameter_schema = Schema.for_tool(tool_def, strict?: strict?)
+      parameter_schema = Schema.for_tool(tool_def, strict?: strict?)
 
-    callback_fn = build_callback(tool_def)
+      callback_fn = build_callback(tool_def)
 
-    tool =
-      ReqLLM.Tool.new!(
-        name: name,
-        description: description,
-        parameter_schema: parameter_schema,
-        callback: fn _args -> {:ok, "stub - should not be called"} end
-      )
+      tool =
+        ReqLLM.Tool.new!(
+          name: name,
+          description: description,
+          parameter_schema: parameter_schema,
+          callback: fn _args -> {:ok, "stub - should not be called"} end
+        )
 
-    {tool, callback_fn}
-  end
-
-  defp build_callback(tool_def) do
-    fn arguments, context ->
-      tool_name = to_string(tool_def.name)
-      callbacks = context[:tool_callbacks] || %{}
-
-      if on_start = callbacks[:on_tool_start] do
-        on_start.(%ToolStartEvent{
-          tool_name: tool_name,
-          action: tool_def.action.name,
-          resource: tool_def.resource,
-          arguments: arguments,
-          actor: context[:actor],
-          tenant: context[:tenant]
-        })
-      end
-
-      result = Execution.run(tool_def, arguments, context)
-
-      if on_end = callbacks[:on_tool_end] do
-        on_end.(%ToolEndEvent{
-          tool_name: tool_name,
-          result: result
-        })
-      end
-
-      result
+      {tool, callback_fn}
     end
+
+    defp build_callback(tool_def) do
+      fn arguments, context ->
+        tool_name = to_string(tool_def.name)
+        callbacks = context[:tool_callbacks] || %{}
+
+        if on_start = callbacks[:on_tool_start] do
+          on_start.(%ToolStartEvent{
+            tool_name: tool_name,
+            action: tool_def.action.name,
+            resource: tool_def.resource,
+            arguments: arguments,
+            actor: context[:actor],
+            tenant: context[:tenant]
+          })
+        end
+
+        result = Execution.run(tool_def, arguments, context)
+
+        if on_end = callbacks[:on_tool_end] do
+          on_end.(%ToolEndEvent{
+            tool_name: tool_name,
+            result: result
+          })
+        end
+
+        result
+      end
+    end
+  end
+else
+  defmodule AshAi.Tool.Builder do
+    @moduledoc "Requires the `req_llm` dependency."
+
+    def build(%AshAi.Tool{}, _opts \\ []),
+      do: AshAi.Dependencies.require_req_llm!("`AshAi.Tool.Builder`")
   end
 end

--- a/lib/ash_ai/tool_loop.ex
+++ b/lib/ash_ai/tool_loop.ex
@@ -2,675 +2,685 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAi.ToolLoop do
-  @moduledoc """
-  Manages a ReqLLM conversation loop with tool calls.
-
-  This module is the primary orchestration API for tool-enabled conversations.
-  """
-
-  alias ReqLLM.Context
-  alias ReqLLM.Message.ContentPart
-
-  defmodule IterationEvent do
+if Code.ensure_loaded?(ReqLLM) do
+  defmodule AshAi.ToolLoop do
     @moduledoc """
-    Event emitted at the start of each iteration in the tool loop.
+    Manages a ReqLLM conversation loop with tool calls.
+
+    This module is the primary orchestration API for tool-enabled conversations.
     """
-    defstruct [:iteration, :messages_count, :tool_calls_count]
-  end
 
-  defmodule Result do
-    @moduledoc """
-    Result returned from a completed tool loop.
+    alias ReqLLM.Context
+    alias ReqLLM.Message.ContentPart
 
-    `:usage` is the token-usage totals summed across every `stream_text/3`
-    call made during the loop (one per iteration). Keys mirror what the
-    underlying ReqLLM provider reports — typically `:input_tokens`,
-    `:output_tokens`, and any cost/cache fields. Numeric fields are summed;
-    non-numeric fields fall through to the most recent value. Empty `%{}`
-    when no provider reported usage.
-    """
-    defstruct [:messages, :final_text, :iterations, :tool_calls_made, usage: %{}]
-  end
-
-  @doc """
-  Runs the tool loop synchronously.
-  """
-  def run(messages, opts) do
-    opts = AshAi.Options.validate!(opts)
-    {tools, registry} = AshAi.Tools.build_tools_and_registry(opts)
-    context = build_context(opts)
-    model = resolve_model(opts.model, opts)
-
-    run_loop(
-      opts.req_llm,
-      model,
-      messages,
-      tools,
-      registry,
-      opts.req_llm_opts,
-      context,
-      1,
-      opts.max_iterations,
-      [],
-      %{}
-    )
-  end
-
-  @doc """
-  Streams events from the tool loop.
-
-  Events:
-  - `{:content, text}`
-  - `{:tool_call, %{id: id, name: name, arguments: args}}`
-  - `{:tool_result, %{id: id, result: result}}`
-  - `{:iteration, %IterationEvent{}}`
-  - `{:error, reason}`
-  - `{:done, %Result{}}`
-  """
-  def stream(messages, opts) do
-    Stream.resource(
-      fn -> init_stream(messages, opts) end,
-      &next_stream_chunk/1,
-      &cleanup_stream/1
-    )
-  end
-
-  defp init_stream(messages, opts) do
-    opts = AshAi.Options.validate!(opts)
-    {tools, registry} = AshAi.Tools.build_tools_and_registry(opts)
-    context = build_context(opts)
-    model = resolve_model(opts.model, opts)
-
-    %{
-      req_llm: opts.req_llm,
-      model: model,
-      messages: messages,
-      tools: tools,
-      registry: registry,
-      req_llm_opts: opts.req_llm_opts,
-      context: context,
-      iteration: 1,
-      max_iterations: opts.max_iterations,
-      tool_calls_made: [],
-      usage_acc: %{},
-      state: :running
-    }
-  end
-
-  defp next_stream_chunk(%{state: :done} = state), do: {:halt, state}
-
-  defp next_stream_chunk(state) do
-    case stream_iteration(state) do
-      {:continue, events, new_state} ->
-        {events, new_state}
-
-      {:done, events, result} ->
-        {events ++ [{:done, result}], %{state | state: :done}}
+    defmodule IterationEvent do
+      @moduledoc """
+      Event emitted at the start of each iteration in the tool loop.
+      """
+      defstruct [:iteration, :messages_count, :tool_calls_count]
     end
-  end
 
-  defp cleanup_stream(_state), do: :ok
+    defmodule Result do
+      @moduledoc """
+      Result returned from a completed tool loop.
 
-  defp stream_iteration(state) do
-    %{
-      req_llm: req_llm,
-      model: model,
-      messages: messages,
-      tools: tools,
-      registry: registry,
-      req_llm_opts: req_llm_opts,
-      context: context,
-      iteration: iteration,
-      max_iterations: max_iterations,
-      tool_calls_made: tool_calls_made,
-      usage_acc: usage_acc
-    } = state
+      `:usage` is the token-usage totals summed across every `stream_text/3`
+      call made during the loop (one per iteration). Keys mirror what the
+      underlying ReqLLM provider reports — typically `:input_tokens`,
+      `:output_tokens`, and any cost/cache fields. Numeric fields are summed;
+      non-numeric fields fall through to the most recent value. Empty `%{}`
+      when no provider reported usage.
+      """
+      defstruct [:messages, :final_text, :iterations, :tool_calls_made, usage: %{}]
+    end
 
-    if max_iterations_reached?(iteration, max_iterations) do
-      result = %Result{
+    @doc """
+    Runs the tool loop synchronously.
+    """
+    def run(messages, opts) do
+      opts = AshAi.Options.validate!(opts)
+      {tools, registry} = AshAi.Tools.build_tools_and_registry(opts)
+      context = build_context(opts)
+      model = resolve_model(opts.model, opts)
+
+      run_loop(
+        opts.req_llm,
+        model,
+        messages,
+        tools,
+        registry,
+        opts.req_llm_opts,
+        context,
+        1,
+        opts.max_iterations,
+        [],
+        %{}
+      )
+    end
+
+    @doc """
+    Streams events from the tool loop.
+
+    Events:
+    - `{:content, text}`
+    - `{:tool_call, %{id: id, name: name, arguments: args}}`
+    - `{:tool_result, %{id: id, result: result}}`
+    - `{:iteration, %IterationEvent{}}`
+    - `{:error, reason}`
+    - `{:done, %Result{}}`
+    """
+    def stream(messages, opts) do
+      Stream.resource(
+        fn -> init_stream(messages, opts) end,
+        &next_stream_chunk/1,
+        &cleanup_stream/1
+      )
+    end
+
+    defp init_stream(messages, opts) do
+      opts = AshAi.Options.validate!(opts)
+      {tools, registry} = AshAi.Tools.build_tools_and_registry(opts)
+      context = build_context(opts)
+      model = resolve_model(opts.model, opts)
+
+      %{
+        req_llm: opts.req_llm,
+        model: model,
         messages: messages,
-        final_text: "",
-        iterations: iteration - 1,
-        tool_calls_made: tool_calls_made,
-        usage: usage_acc
+        tools: tools,
+        registry: registry,
+        req_llm_opts: opts.req_llm_opts,
+        context: context,
+        iteration: 1,
+        max_iterations: opts.max_iterations,
+        tool_calls_made: [],
+        usage_acc: %{},
+        state: :running
       }
+    end
 
-      {:done, [{:error, :max_iterations_reached}], result}
-    else
-      case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
-        {:ok, stream_response} ->
-          chunks = Enum.to_list(stream_response.stream)
-          content_events = content_events(chunks)
-          chunk_tool_call_ids = chunk_tool_call_ids(chunks)
-          usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
+    defp next_stream_chunk(%{state: :done} = state), do: {:halt, state}
 
-          classification =
-            stream_response
-            |> Map.put(:stream, chunks)
-            |> ReqLLM.StreamResponse.classify()
+    defp next_stream_chunk(state) do
+      case stream_iteration(state) do
+        {:continue, events, new_state} ->
+          {events, new_state}
 
-          if classification.type == :tool_calls do
-            tool_calls =
-              classification.tool_calls
-              |> normalize_tool_calls(chunk_tool_call_ids)
-              |> unprocessed_tool_calls(messages)
+        {:done, events, result} ->
+          {events ++ [{:done, result}], %{state | state: :done}}
+      end
+    end
 
-            messages =
-              append_tool_call_turn(
-                messages,
-                classification.text,
-                classification.thinking,
-                tool_calls
-              )
+    defp cleanup_stream(_state), do: :ok
 
-            {messages, tool_events} = run_tools_streaming(tool_calls, messages, registry, context)
+    defp stream_iteration(state) do
+      %{
+        req_llm: req_llm,
+        model: model,
+        messages: messages,
+        tools: tools,
+        registry: registry,
+        req_llm_opts: req_llm_opts,
+        context: context,
+        iteration: iteration,
+        max_iterations: max_iterations,
+        tool_calls_made: tool_calls_made,
+        usage_acc: usage_acc
+      } = state
 
-            new_state = %{
-              state
-              | messages: messages,
-                iteration: iteration + 1,
-                tool_calls_made: tool_calls_made ++ tool_calls,
-                usage_acc: usage_acc
-            }
+      if max_iterations_reached?(iteration, max_iterations) do
+        result = %Result{
+          messages: messages,
+          final_text: "",
+          iterations: iteration - 1,
+          tool_calls_made: tool_calls_made,
+          usage: usage_acc
+        }
 
-            {:continue,
-             content_events ++
-               Enum.map(tool_calls, &{:tool_call, &1}) ++
-               tool_events ++
-               [{:iteration, %IterationEvent{iteration: iteration + 1}}], new_state}
-          else
-            messages =
-              maybe_append_assistant_message(
-                messages,
-                classification.text,
-                classification.thinking,
-                model
-              )
+        {:done, [{:error, :max_iterations_reached}], result}
+      else
+        case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
+          {:ok, stream_response} ->
+            chunks = Enum.to_list(stream_response.stream)
+            content_events = content_events(chunks)
+            chunk_tool_call_ids = chunk_tool_call_ids(chunks)
+            usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
 
+            classification =
+              stream_response
+              |> Map.put(:stream, chunks)
+              |> ReqLLM.StreamResponse.classify()
+
+            if classification.type == :tool_calls do
+              tool_calls =
+                classification.tool_calls
+                |> normalize_tool_calls(chunk_tool_call_ids)
+                |> unprocessed_tool_calls(messages)
+
+              messages =
+                append_tool_call_turn(
+                  messages,
+                  classification.text,
+                  classification.thinking,
+                  tool_calls
+                )
+
+              {messages, tool_events} =
+                run_tools_streaming(tool_calls, messages, registry, context)
+
+              new_state = %{
+                state
+                | messages: messages,
+                  iteration: iteration + 1,
+                  tool_calls_made: tool_calls_made ++ tool_calls,
+                  usage_acc: usage_acc
+              }
+
+              {:continue,
+               content_events ++
+                 Enum.map(tool_calls, &{:tool_call, &1}) ++
+                 tool_events ++
+                 [{:iteration, %IterationEvent{iteration: iteration + 1}}], new_state}
+            else
+              messages =
+                maybe_append_assistant_message(
+                  messages,
+                  classification.text,
+                  classification.thinking,
+                  model
+                )
+
+              result = %Result{
+                messages: messages,
+                final_text: classification.text,
+                iterations: iteration,
+                tool_calls_made: tool_calls_made,
+                usage: usage_acc
+              }
+
+              {:done, content_events, result}
+            end
+
+          {:error, reason} ->
             result = %Result{
               messages: messages,
-              final_text: classification.text,
-              iterations: iteration,
+              final_text: "",
+              iterations: iteration - 1,
               tool_calls_made: tool_calls_made,
               usage: usage_acc
             }
 
-            {:done, content_events, result}
-          end
-
-        {:error, reason} ->
-          result = %Result{
-            messages: messages,
-            final_text: "",
-            iterations: iteration - 1,
-            tool_calls_made: tool_calls_made,
-            usage: usage_acc
-          }
-
-          {:done, [{:error, reason}], result}
+            {:done, [{:error, reason}], result}
+        end
       end
     end
-  end
 
-  defp content_events(chunks) do
-    chunks
-    |> Enum.filter(&(&1.type == :content))
-    |> Enum.map(fn chunk -> {:content, chunk.text || ""} end)
-  end
+    defp content_events(chunks) do
+      chunks
+      |> Enum.filter(&(&1.type == :content))
+      |> Enum.map(fn chunk -> {:content, chunk.text || ""} end)
+    end
 
-  # Sums per-iteration usage maps into a running accumulator. Numeric
-  # fields (input_tokens, output_tokens, cached_tokens, *_cost, ...) are
-  # summed so the final `Result.usage` reflects everything billed across
-  # the entire tool loop. Non-numeric fields fall through to the most
-  # recent iteration's value, since they're typically per-call metadata
-  # like `:provider_meta` or `:model`.
-  defp accumulate_usage(acc, nil), do: acc
-  defp accumulate_usage(acc, usage) when usage == %{}, do: acc
+    # Sums per-iteration usage maps into a running accumulator. Numeric
+    # fields (input_tokens, output_tokens, cached_tokens, *_cost, ...) are
+    # summed so the final `Result.usage` reflects everything billed across
+    # the entire tool loop. Non-numeric fields fall through to the most
+    # recent iteration's value, since they're typically per-call metadata
+    # like `:provider_meta` or `:model`.
+    defp accumulate_usage(acc, nil), do: acc
+    defp accumulate_usage(acc, usage) when usage == %{}, do: acc
 
-  defp accumulate_usage(acc, usage) when is_map(usage) do
-    Map.merge(acc, usage, fn
-      _key, a, b when is_number(a) and is_number(b) -> a + b
-      _key, _a, b -> b
-    end)
-  end
+    defp accumulate_usage(acc, usage) when is_map(usage) do
+      Map.merge(acc, usage, fn
+        _key, a, b when is_number(a) and is_number(b) -> a + b
+        _key, _a, b -> b
+      end)
+    end
 
-  # ReqLLM.StreamResponse.usage/1 awaits a metadata-handle pid; test
-  # fixtures stub the field with non-pid values like `:ignored`, so we
-  # guard against that here rather than failing the whole loop.
-  defp safe_stream_usage(%{metadata_handle: handle} = stream_response) when is_pid(handle) do
-    ReqLLM.StreamResponse.usage(stream_response)
-  end
+    # ReqLLM.StreamResponse.usage/1 awaits a metadata-handle pid; test
+    # fixtures stub the field with non-pid values like `:ignored`, so we
+    # guard against that here rather than failing the whole loop.
+    defp safe_stream_usage(%{metadata_handle: handle} = stream_response) when is_pid(handle) do
+      ReqLLM.StreamResponse.usage(stream_response)
+    end
 
-  defp safe_stream_usage(_), do: nil
+    defp safe_stream_usage(_), do: nil
 
-  defp run_tools_streaming(tool_calls, messages, registry, ctx) do
-    Enum.reduce(tool_calls, {messages, []}, fn tool_call, {msgs, events} ->
-      case run_single_tool(tool_call, registry, ctx) do
-        {result, content} ->
-          {
-            msgs ++ [Context.tool_result(tool_call.id, content)],
-            events ++ [{:tool_result, %{id: tool_call.id, result: result}}]
-          }
-      end
-    end)
-  end
+    defp run_tools_streaming(tool_calls, messages, registry, ctx) do
+      Enum.reduce(tool_calls, {messages, []}, fn tool_call, {msgs, events} ->
+        case run_single_tool(tool_call, registry, ctx) do
+          {result, content} ->
+            {
+              msgs ++ [Context.tool_result(tool_call.id, content)],
+              events ++ [{:tool_result, %{id: tool_call.id, result: result}}]
+            }
+        end
+      end)
+    end
 
-  defp build_context(opts) do
-    %{
-      actor: opts.actor,
-      tenant: opts.tenant,
-      context: opts.context,
-      tool_callbacks: %{
-        on_tool_start: opts.on_tool_start,
-        on_tool_end: opts.on_tool_end
+    defp build_context(opts) do
+      %{
+        actor: opts.actor,
+        tenant: opts.tenant,
+        context: opts.context,
+        tool_callbacks: %{
+          on_tool_start: opts.on_tool_start,
+          on_tool_end: opts.on_tool_end
+        }
       }
-    }
-  end
-
-  defp req_llm_stream_opts(req_llm_opts, tools) do
-    req_llm_opts
-    |> Keyword.drop([:tools])
-    |> Keyword.put(:tools, tools)
-  end
-
-  defp resolve_model(model, opts) when is_function(model, 1),
-    do: resolve_model(model.(opts), opts)
-
-  defp resolve_model(model, _opts) when is_function(model, 0), do: model.()
-  defp resolve_model(model, _opts), do: ReqLLM.model!(model)
-
-  defp run_loop(
-         req_llm,
-         model,
-         messages,
-         tools,
-         registry,
-         req_llm_opts,
-         context,
-         iteration,
-         max_iterations,
-         tool_calls_made,
-         usage_acc
-       ) do
-    if max_iterations_reached?(iteration, max_iterations) do
-      {:error, :max_iterations_reached}
-    else
-      case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
-        {:ok, stream_response} ->
-          chunks = Enum.to_list(stream_response.stream)
-          chunk_tool_call_ids = chunk_tool_call_ids(chunks)
-          usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
-
-          classification =
-            stream_response
-            |> Map.put(:stream, chunks)
-            |> ReqLLM.StreamResponse.classify()
-
-          if classification.type == :tool_calls do
-            tool_calls =
-              classification.tool_calls
-              |> normalize_tool_calls(chunk_tool_call_ids)
-              |> unprocessed_tool_calls(messages)
-
-            messages =
-              append_tool_call_turn(
-                messages,
-                classification.text,
-                classification.thinking,
-                tool_calls
-              )
-
-            messages = run_tools(tool_calls, messages, registry, context)
-
-            run_loop(
-              req_llm,
-              model,
-              messages,
-              tools,
-              registry,
-              req_llm_opts,
-              context,
-              iteration + 1,
-              max_iterations,
-              tool_calls_made ++ tool_calls,
-              usage_acc
-            )
-          else
-            messages =
-              maybe_append_assistant_message(
-                messages,
-                classification.text,
-                classification.thinking,
-                model
-              )
-
-            {:ok,
-             %Result{
-               messages: messages,
-               final_text: classification.text,
-               iterations: iteration,
-               tool_calls_made: tool_calls_made,
-               usage: usage_acc
-             }}
-          end
-
-        {:error, reason} ->
-          {:error, reason}
-      end
     end
-  end
 
-  defp run_tools(tool_calls, messages, registry, ctx) do
-    Enum.reduce(tool_calls, messages, fn tool_call, msgs ->
-      {_, content} = run_single_tool(tool_call, registry, ctx)
-      msgs ++ [Context.tool_result(tool_call.id, content)]
-    end)
-  end
+    defp req_llm_stream_opts(req_llm_opts, tools) do
+      req_llm_opts
+      |> Keyword.drop([:tools])
+      |> Keyword.put(:tools, tools)
+    end
 
-  defp run_single_tool(tool_call, registry, ctx) do
-    fun = Map.get(registry, tool_call.name)
+    defp resolve_model(model, opts) when is_function(model, 1),
+      do: resolve_model(model.(opts), opts)
 
-    if is_nil(fun) do
-      content = Jason.encode!(%{error: "Unknown tool: #{tool_call.name}"})
-      {{:error, content}, content}
-    else
-      result =
-        case decode_tool_call_arguments(tool_call.arguments) do
-          {:ok, args} ->
-            try do
-              fun.(args, ctx)
-            rescue
-              e ->
-                {:error, Jason.encode!(%{error: Exception.message(e)})}
+    defp resolve_model(model, _opts) when is_function(model, 0), do: model.()
+    defp resolve_model(model, _opts), do: ReqLLM.model!(model)
+
+    defp run_loop(
+           req_llm,
+           model,
+           messages,
+           tools,
+           registry,
+           req_llm_opts,
+           context,
+           iteration,
+           max_iterations,
+           tool_calls_made,
+           usage_acc
+         ) do
+      if max_iterations_reached?(iteration, max_iterations) do
+        {:error, :max_iterations_reached}
+      else
+        case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
+          {:ok, stream_response} ->
+            chunks = Enum.to_list(stream_response.stream)
+            chunk_tool_call_ids = chunk_tool_call_ids(chunks)
+            usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
+
+            classification =
+              stream_response
+              |> Map.put(:stream, chunks)
+              |> ReqLLM.StreamResponse.classify()
+
+            if classification.type == :tool_calls do
+              tool_calls =
+                classification.tool_calls
+                |> normalize_tool_calls(chunk_tool_call_ids)
+                |> unprocessed_tool_calls(messages)
+
+              messages =
+                append_tool_call_turn(
+                  messages,
+                  classification.text,
+                  classification.thinking,
+                  tool_calls
+                )
+
+              messages = run_tools(tool_calls, messages, registry, context)
+
+              run_loop(
+                req_llm,
+                model,
+                messages,
+                tools,
+                registry,
+                req_llm_opts,
+                context,
+                iteration + 1,
+                max_iterations,
+                tool_calls_made ++ tool_calls,
+                usage_acc
+              )
+            else
+              messages =
+                maybe_append_assistant_message(
+                  messages,
+                  classification.text,
+                  classification.thinking,
+                  model
+                )
+
+              {:ok,
+               %Result{
+                 messages: messages,
+                 final_text: classification.text,
+                 iterations: iteration,
+                 tool_calls_made: tool_calls_made,
+                 usage: usage_acc
+               }}
             end
 
           {:error, reason} ->
-            {:error, Jason.encode!(%{error: reason})}
+            {:error, reason}
         end
-
-      content =
-        case result do
-          {:ok, content, _raw} -> content
-          {:error, content} -> content
-        end
-
-      {result, content}
-    end
-  end
-
-  defp decode_tool_call_arguments(s) when is_binary(s) do
-    case Jason.decode(s) do
-      {:ok, m} when is_map(m) ->
-        {:ok, m}
-
-      {:ok, other} ->
-        {:error, "Invalid tool arguments JSON type: #{inspect(other)}"}
-
-      {:error, error} ->
-        {:error, "Invalid tool arguments JSON: #{Exception.message(error)}"}
-    end
-  end
-
-  defp decode_tool_call_arguments(m) when is_map(m), do: {:ok, m}
-  defp decode_tool_call_arguments(_), do: {:ok, %{}}
-
-  defp maybe_append_assistant_message(messages, _text, _thinking, %{provider: :anthropic}),
-    do: messages
-
-  defp maybe_append_assistant_message(messages, text, thinking, _model)
-       when is_binary(text) and text != "" do
-    content = build_assistant_content(text, thinking)
-    messages ++ [Context.assistant(content)]
-  end
-
-  defp maybe_append_assistant_message(messages, _, _, _), do: messages
-
-  defp build_assistant_content(text, thinking) do
-    parts = []
-    parts = if text != "", do: parts ++ [ContentPart.text(text)], else: parts
-
-    parts =
-      if thinking != "", do: parts ++ [ContentPart.thinking(thinking)], else: parts
-
-    parts
-  end
-
-  defp chunk_tool_call_ids(chunks) do
-    chunks
-    |> Enum.filter(&(&1.type == :tool_call))
-    |> Enum.map(fn chunk ->
-      metadata = chunk.metadata || %{}
-      metadata_field(metadata, :id) || metadata_field(metadata, :call_id)
-    end)
-  end
-
-  defp normalize_tool_calls(tool_calls, chunk_tool_call_ids) do
-    tool_calls
-    |> List.wrap()
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {tool_call, index} ->
-      case normalize_tool_call(tool_call, Enum.at(chunk_tool_call_ids, index)) do
-        nil -> []
-        normalized -> [normalized]
       end
-    end)
-  end
+    end
 
-  defp normalize_tool_call(%ReqLLM.ToolCall{} = tool_call, chunk_id) do
-    tool_call
-    |> ReqLLM.ToolCall.to_map()
-    |> normalize_tool_call(chunk_id)
-  end
+    defp run_tools(tool_calls, messages, registry, ctx) do
+      Enum.reduce(tool_calls, messages, fn tool_call, msgs ->
+        {_, content} = run_single_tool(tool_call, registry, ctx)
+        msgs ++ [Context.tool_result(tool_call.id, content)]
+      end)
+    end
 
-  defp normalize_tool_call(tool_call, chunk_id) when is_map(tool_call) do
-    name =
-      Map.get(tool_call, :name) ||
-        Map.get(tool_call, "name") ||
-        get_in(tool_call, [:function, :name]) ||
-        get_in(tool_call, ["function", "name"])
+    defp run_single_tool(tool_call, registry, ctx) do
+      fun = Map.get(registry, tool_call.name)
 
-    arguments =
-      Map.get(tool_call, :arguments) ||
-        Map.get(tool_call, "arguments") ||
-        get_in(tool_call, [:function, :arguments]) ||
-        get_in(tool_call, ["function", "arguments"]) ||
-        %{}
+      if is_nil(fun) do
+        content = Jason.encode!(%{error: "Unknown tool: #{tool_call.name}"})
+        {{:error, content}, content}
+      else
+        result =
+          case decode_tool_call_arguments(tool_call.arguments) do
+            {:ok, args} ->
+              try do
+                fun.(args, ctx)
+              rescue
+                e ->
+                  {:error, Jason.encode!(%{error: Exception.message(e)})}
+              end
 
-    id =
-      chunk_id ||
-        Map.get(tool_call, :id) ||
+            {:error, reason} ->
+              {:error, Jason.encode!(%{error: reason})}
+          end
+
+        content =
+          case result do
+            {:ok, content, _raw} -> content
+            {:error, content} -> content
+          end
+
+        {result, content}
+      end
+    end
+
+    defp decode_tool_call_arguments(s) when is_binary(s) do
+      case Jason.decode(s) do
+        {:ok, m} when is_map(m) ->
+          {:ok, m}
+
+        {:ok, other} ->
+          {:error, "Invalid tool arguments JSON type: #{inspect(other)}"}
+
+        {:error, error} ->
+          {:error, "Invalid tool arguments JSON: #{Exception.message(error)}"}
+      end
+    end
+
+    defp decode_tool_call_arguments(m) when is_map(m), do: {:ok, m}
+    defp decode_tool_call_arguments(_), do: {:ok, %{}}
+
+    defp maybe_append_assistant_message(messages, _text, _thinking, %{provider: :anthropic}),
+      do: messages
+
+    defp maybe_append_assistant_message(messages, text, thinking, _model)
+         when is_binary(text) and text != "" do
+      content = build_assistant_content(text, thinking)
+      messages ++ [Context.assistant(content)]
+    end
+
+    defp maybe_append_assistant_message(messages, _, _, _), do: messages
+
+    defp build_assistant_content(text, thinking) do
+      parts = []
+      parts = if text != "", do: parts ++ [ContentPart.text(text)], else: parts
+
+      parts =
+        if thinking != "", do: parts ++ [ContentPart.thinking(thinking)], else: parts
+
+      parts
+    end
+
+    defp chunk_tool_call_ids(chunks) do
+      chunks
+      |> Enum.filter(&(&1.type == :tool_call))
+      |> Enum.map(fn chunk ->
+        metadata = chunk.metadata || %{}
+        metadata_field(metadata, :id) || metadata_field(metadata, :call_id)
+      end)
+    end
+
+    defp normalize_tool_calls(tool_calls, chunk_tool_call_ids) do
+      tool_calls
+      |> List.wrap()
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {tool_call, index} ->
+        case normalize_tool_call(tool_call, Enum.at(chunk_tool_call_ids, index)) do
+          nil -> []
+          normalized -> [normalized]
+        end
+      end)
+    end
+
+    defp normalize_tool_call(%ReqLLM.ToolCall{} = tool_call, chunk_id) do
+      tool_call
+      |> ReqLLM.ToolCall.to_map()
+      |> normalize_tool_call(chunk_id)
+    end
+
+    defp normalize_tool_call(tool_call, chunk_id) when is_map(tool_call) do
+      name =
+        Map.get(tool_call, :name) ||
+          Map.get(tool_call, "name") ||
+          get_in(tool_call, [:function, :name]) ||
+          get_in(tool_call, ["function", "name"])
+
+      arguments =
+        Map.get(tool_call, :arguments) ||
+          Map.get(tool_call, "arguments") ||
+          get_in(tool_call, [:function, :arguments]) ||
+          get_in(tool_call, ["function", "arguments"]) ||
+          %{}
+
+      id =
+        chunk_id ||
+          Map.get(tool_call, :id) ||
+          Map.get(tool_call, "id") ||
+          Map.get(tool_call, :call_id) ||
+          Map.get(tool_call, "call_id")
+
+      if is_binary(name) and name != "" do
+        %{
+          id: normalize_tool_call_id(id),
+          name: name,
+          arguments: normalize_tool_call_arguments(arguments)
+        }
+      else
+        nil
+      end
+    end
+
+    defp normalize_tool_call(_tool_call, _chunk_id), do: nil
+
+    defp normalize_tool_call_id(id) when is_binary(id) and id != "", do: id
+    defp normalize_tool_call_id(id) when is_atom(id), do: Atom.to_string(id)
+    defp normalize_tool_call_id(id) when is_number(id), do: to_string(id)
+    defp normalize_tool_call_id(_), do: generate_tool_id()
+
+    defp normalize_tool_call_arguments(arguments) when is_map(arguments), do: arguments
+
+    defp normalize_tool_call_arguments(arguments) when is_binary(arguments) do
+      case Jason.decode(arguments) do
+        {:ok, parsed} when is_map(parsed) -> parsed
+        _ -> arguments
+      end
+    end
+
+    defp normalize_tool_call_arguments(_), do: %{}
+
+    defp append_tool_call_turn(messages, _text, _thinking, []), do: messages
+
+    defp append_tool_call_turn(messages, text, thinking, tool_calls) do
+      case merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
+        {:ok, merged_messages} ->
+          merged_messages
+
+        :no_merge ->
+          content = build_assistant_content(text, thinking)
+          messages ++ [Context.assistant(content, tool_calls: tool_calls)]
+      end
+    end
+
+    defp merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
+      {trailing_tools_rev, rest_rev} =
+        messages
+        |> Enum.reverse()
+        |> Enum.split_while(fn message -> Map.get(message, :role) == :tool end)
+
+      trailing_tools = Enum.reverse(trailing_tools_rev)
+      rest = Enum.reverse(rest_rev)
+
+      case List.last(rest) do
+        %{role: :assistant} = assistant ->
+          if has_tool_calls?(assistant.tool_calls) do
+            prefix = Enum.drop(rest, -1)
+
+            merged_tool_calls =
+              merge_tool_call_lists(
+                assistant.tool_calls,
+                normalize_context_tool_calls(tool_calls)
+              )
+
+            merged_assistant = %{
+              assistant
+              | tool_calls: merged_tool_calls,
+                content: merge_assistant_content(assistant.content, text, thinking)
+            }
+
+            {:ok, prefix ++ [merged_assistant] ++ trailing_tools}
+          else
+            :no_merge
+          end
+
+        _ ->
+          :no_merge
+      end
+    end
+
+    defp unprocessed_tool_calls(tool_calls, messages) do
+      processed_ids =
+        messages
+        |> Enum.filter(fn message -> Map.get(message, :role) == :tool end)
+        |> Enum.map(&Map.get(&1, :tool_call_id))
+        |> Enum.filter(&is_binary/1)
+        |> MapSet.new()
+
+      Enum.reject(List.wrap(tool_calls), fn tool_call ->
+        case tool_call_id(tool_call) do
+          id when is_binary(id) -> MapSet.member?(processed_ids, id)
+          _ -> false
+        end
+      end)
+    end
+
+    defp merge_tool_call_lists(existing, new_calls) do
+      {merged, _seen_ids} =
+        Enum.reduce(List.wrap(existing) ++ List.wrap(new_calls), {[], MapSet.new()}, fn
+          call, {acc, seen} ->
+            case tool_call_id(call) do
+              id when is_binary(id) ->
+                if MapSet.member?(seen, id) do
+                  {acc, seen}
+                else
+                  {acc ++ [call], MapSet.put(seen, id)}
+                end
+
+              _ ->
+                {acc ++ [call], seen}
+            end
+        end)
+
+      merged
+    end
+
+    defp tool_call_id(%ReqLLM.ToolCall{} = tool_call), do: tool_call.id
+
+    defp tool_call_id(tool_call) when is_map(tool_call) do
+      Map.get(tool_call, :id) ||
         Map.get(tool_call, "id") ||
         Map.get(tool_call, :call_id) ||
         Map.get(tool_call, "call_id")
-
-    if is_binary(name) and name != "" do
-      %{
-        id: normalize_tool_call_id(id),
-        name: name,
-        arguments: normalize_tool_call_arguments(arguments)
-      }
-    else
-      nil
     end
-  end
 
-  defp normalize_tool_call(_tool_call, _chunk_id), do: nil
+    defp tool_call_id(_), do: nil
 
-  defp normalize_tool_call_id(id) when is_binary(id) and id != "", do: id
-  defp normalize_tool_call_id(id) when is_atom(id), do: Atom.to_string(id)
-  defp normalize_tool_call_id(id) when is_number(id), do: to_string(id)
-  defp normalize_tool_call_id(_), do: generate_tool_id()
+    defp has_tool_calls?(tool_calls) when is_list(tool_calls), do: tool_calls != []
+    defp has_tool_calls?(_), do: false
 
-  defp normalize_tool_call_arguments(arguments) when is_map(arguments), do: arguments
-
-  defp normalize_tool_call_arguments(arguments) when is_binary(arguments) do
-    case Jason.decode(arguments) do
-      {:ok, parsed} when is_map(parsed) -> parsed
-      _ -> arguments
+    defp normalize_context_tool_calls(tool_calls) do
+      Context.assistant("", tool_calls: tool_calls).tool_calls || []
     end
-  end
 
-  defp normalize_tool_call_arguments(_), do: %{}
+    defp merge_assistant_content(content, _text, _thinking) when content == [], do: content
 
-  defp append_tool_call_turn(messages, _text, _thinking, []), do: messages
+    defp merge_assistant_content(content, text, _thinking) when text in [nil, ""], do: content
 
-  defp append_tool_call_turn(messages, text, thinking, tool_calls) do
-    case merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
-      {:ok, merged_messages} ->
-        merged_messages
+    defp merge_assistant_content(content, text, thinking) do
+      existing_text = assistant_text(content)
 
-      :no_merge ->
-        content = build_assistant_content(text, thinking)
-        messages ++ [Context.assistant(content, tool_calls: tool_calls)]
-    end
-  end
-
-  defp merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
-    {trailing_tools_rev, rest_rev} =
-      messages
-      |> Enum.reverse()
-      |> Enum.split_while(fn message -> Map.get(message, :role) == :tool end)
-
-    trailing_tools = Enum.reverse(trailing_tools_rev)
-    rest = Enum.reverse(rest_rev)
-
-    case List.last(rest) do
-      %{role: :assistant} = assistant ->
-        if has_tool_calls?(assistant.tool_calls) do
-          prefix = Enum.drop(rest, -1)
-
-          merged_tool_calls =
-            merge_tool_call_lists(
-              assistant.tool_calls,
-              normalize_context_tool_calls(tool_calls)
-            )
-
-          merged_assistant = %{
-            assistant
-            | tool_calls: merged_tool_calls,
-              content: merge_assistant_content(assistant.content, text, thinking)
-          }
-
-          {:ok, prefix ++ [merged_assistant] ++ trailing_tools}
+      combined_text =
+        if existing_text == "" do
+          text
         else
-          :no_merge
+          existing_text <> "\n" <> text
         end
 
-      _ ->
-        :no_merge
+      # Preserve non-text content parts (e.g. thinking, images) unless
+      # new thinking is provided, in which case we replace old thinking.
+      other_parts =
+        Enum.reject(content, fn
+          %ContentPart{type: :text} -> true
+          %{type: :text} -> true
+          _ -> false
+        end)
+
+      parts = [ContentPart.text(combined_text)]
+
+      parts =
+        if thinking != "" do
+          parts ++ [ContentPart.thinking(thinking)]
+        else
+          parts ++ other_parts
+        end
+
+      parts
     end
-  end
 
-  defp unprocessed_tool_calls(tool_calls, messages) do
-    processed_ids =
-      messages
-      |> Enum.filter(fn message -> Map.get(message, :role) == :tool end)
-      |> Enum.map(&Map.get(&1, :tool_call_id))
-      |> Enum.filter(&is_binary/1)
-      |> MapSet.new()
-
-    Enum.reject(List.wrap(tool_calls), fn tool_call ->
-      case tool_call_id(tool_call) do
-        id when is_binary(id) -> MapSet.member?(processed_ids, id)
-        _ -> false
-      end
-    end)
-  end
-
-  defp merge_tool_call_lists(existing, new_calls) do
-    {merged, _seen_ids} =
-      Enum.reduce(List.wrap(existing) ++ List.wrap(new_calls), {[], MapSet.new()}, fn call,
-                                                                                      {acc, seen} ->
-        case tool_call_id(call) do
-          id when is_binary(id) ->
-            if MapSet.member?(seen, id) do
-              {acc, seen}
-            else
-              {acc ++ [call], MapSet.put(seen, id)}
-            end
-
-          _ ->
-            {acc ++ [call], seen}
-        end
+    defp assistant_text(content_parts) when is_list(content_parts) do
+      content_parts
+      |> Enum.map_join(fn
+        %ContentPart{type: :text, text: text} when is_binary(text) -> text
+        %{type: :text, text: text} when is_binary(text) -> text
+        _ -> ""
       end)
+      |> String.trim()
+    end
 
-    merged
+    defp assistant_text(_), do: ""
+
+    defp metadata_field(metadata, key) when is_map(metadata) do
+      Map.get(metadata, key) || Map.get(metadata, to_string(key))
+    end
+
+    defp generate_tool_id do
+      "call_#{:erlang.unique_integer([:positive])}"
+    end
+
+    defp max_iterations_reached?(_iteration, :infinity), do: false
+    defp max_iterations_reached?(iteration, max_iterations), do: iteration > max_iterations
   end
+else
+  defmodule AshAi.ToolLoop do
+    @moduledoc "Requires the `req_llm` dependency."
 
-  defp tool_call_id(%ReqLLM.ToolCall{} = tool_call), do: tool_call.id
-
-  defp tool_call_id(tool_call) when is_map(tool_call) do
-    Map.get(tool_call, :id) ||
-      Map.get(tool_call, "id") ||
-      Map.get(tool_call, :call_id) ||
-      Map.get(tool_call, "call_id")
+    def run(_messages, _opts), do: AshAi.Dependencies.require_req_llm!("`AshAi.ToolLoop`")
+    def stream(_messages, _opts), do: AshAi.Dependencies.require_req_llm!("`AshAi.ToolLoop`")
   end
-
-  defp tool_call_id(_), do: nil
-
-  defp has_tool_calls?(tool_calls) when is_list(tool_calls), do: tool_calls != []
-  defp has_tool_calls?(_), do: false
-
-  defp normalize_context_tool_calls(tool_calls) do
-    Context.assistant("", tool_calls: tool_calls).tool_calls || []
-  end
-
-  defp merge_assistant_content(content, _text, _thinking) when content == [], do: content
-
-  defp merge_assistant_content(content, text, _thinking) when text in [nil, ""], do: content
-
-  defp merge_assistant_content(content, text, thinking) do
-    existing_text = assistant_text(content)
-
-    combined_text =
-      if existing_text == "" do
-        text
-      else
-        existing_text <> "\n" <> text
-      end
-
-    # Preserve non-text content parts (e.g. thinking, images) unless
-    # new thinking is provided, in which case we replace old thinking.
-    other_parts =
-      Enum.reject(content, fn
-        %ContentPart{type: :text} -> true
-        %{type: :text} -> true
-        _ -> false
-      end)
-
-    parts = [ContentPart.text(combined_text)]
-
-    parts =
-      if thinking != "" do
-        parts ++ [ContentPart.thinking(thinking)]
-      else
-        parts ++ other_parts
-      end
-
-    parts
-  end
-
-  defp assistant_text(content_parts) when is_list(content_parts) do
-    content_parts
-    |> Enum.map_join(fn
-      %ContentPart{type: :text, text: text} when is_binary(text) -> text
-      %{type: :text, text: text} when is_binary(text) -> text
-      _ -> ""
-    end)
-    |> String.trim()
-  end
-
-  defp assistant_text(_), do: ""
-
-  defp metadata_field(metadata, key) when is_map(metadata) do
-    Map.get(metadata, key) || Map.get(metadata, to_string(key))
-  end
-
-  defp generate_tool_id do
-    "call_#{:erlang.unique_integer([:positive])}"
-  end
-
-  defp max_iterations_reached?(_iteration, :infinity), do: false
-  defp max_iterations_reached?(iteration, max_iterations), do: iteration > max_iterations
 end

--- a/lib/ash_ai/tools.ex
+++ b/lib/ash_ai/tools.ex
@@ -19,8 +19,8 @@ defmodule AshAi.Tools do
   - `AshAi.Tool.Builder` - Creates ReqLLM.Tool structs and callbacks
   """
 
-  alias AshAi.{Tool, ToolEndEvent, ToolStartEvent}
-  alias AshAi.Tool.{Builder, Execution, Schema}
+  alias AshAi.Tool
+  alias AshAi.Tool.{Execution, Schema}
 
   @doc """
   Returns the JSON Schema parameter schema for a tool definition.
@@ -46,152 +46,175 @@ defmodule AshAi.Tools do
   end
 
   @doc """
-  Builds a ReqLLM.Tool and callback from a tool definition.
+  Returns the description exposed to LLM clients for a tool definition.
 
-  Delegates to `AshAi.Tool.Builder.build/2`.
-
-  Returns `{ReqLLM.Tool, callback_fn}` tuple.
+  Falls back to the action description, then to a generic sentence.
   """
-  def build(%Tool{} = tool, opts \\ []) do
-    Builder.build(tool, opts)
+  def description(%Tool{} = tool) do
+    String.trim(
+      tool.description || tool.action.description || "Call the #{tool.action.name} tool"
+    )
   end
 
-  @doc """
-  Builds tools and a registry from options.
+  if Code.ensure_loaded?(ReqLLM) do
+    alias AshAi.Tool.Builder
+    alias AshAi.{ToolEndEvent, ToolStartEvent}
 
-  Returns `{[ReqLLM.Tool], %{name => callback}}` tuple.
-  """
-  def build_tools_and_registry(opts) do
-    opts = if is_list(opts), do: AshAi.Options.validate!(opts), else: opts
+    @doc """
+    Builds a ReqLLM.Tool and callback from a tool definition.
 
-    ash_tool_tuples =
+    Delegates to `AshAi.Tool.Builder.build/2`.
+
+    Returns `{ReqLLM.Tool, callback_fn}` tuple.
+    """
+    def build(%Tool{} = tool, opts \\ []) do
+      Builder.build(tool, opts)
+    end
+
+    @doc """
+    Builds tools and a registry from options.
+
+    Returns `{[ReqLLM.Tool], %{name => callback}}` tuple.
+    """
+    def build_tools_and_registry(opts) do
+      opts = if is_list(opts), do: AshAi.Options.validate!(opts), else: opts
+
+      ash_tool_tuples =
+        opts
+        |> AshAi.exposed_tools()
+        |> Enum.map(&Builder.build(&1, strict: opts.strict))
+
+      extra_tool_tuples = build_extra_tools(opts.extra_tools || [])
+      tool_tuples = ensure_unique_tool_names!(ash_tool_tuples ++ extra_tool_tuples)
+
+      {tools, callbacks} =
+        case tool_tuples do
+          [] -> {[], []}
+          tuples -> Enum.unzip(tuples)
+        end
+
+      registry =
+        Enum.zip(tools, callbacks)
+        |> Enum.into(%{}, fn {tool, callback} -> {tool.name, callback} end)
+
+      {tools, registry}
+    end
+
+    @doc """
+    Returns a list of ReqLLM.Tool structs for the given options.
+    """
+    def list(opts) do
       opts
-      |> AshAi.exposed_tools()
-      |> Enum.map(&Builder.build(&1, strict: opts.strict))
-
-    extra_tool_tuples = build_extra_tools(opts.extra_tools || [])
-    tool_tuples = ensure_unique_tool_names!(ash_tool_tuples ++ extra_tool_tuples)
-
-    {tools, callbacks} =
-      case tool_tuples do
-        [] -> {[], []}
-        tuples -> Enum.unzip(tuples)
-      end
-
-    registry =
-      Enum.zip(tools, callbacks)
-      |> Enum.into(%{}, fn {tool, callback} -> {tool.name, callback} end)
-
-    {tools, registry}
-  end
-
-  @doc """
-  Returns a list of ReqLLM.Tool structs for the given options.
-  """
-  def list(opts) do
-    opts
-    |> build_tools_and_registry()
-    |> elem(0)
-  end
-
-  @doc """
-  Returns a registry map of tool names to callbacks.
-  """
-  def registry(opts) do
-    opts
-    |> build_tools_and_registry()
-    |> elem(1)
-  end
-
-  defp build_extra_tools(extra_tools) when is_list(extra_tools) do
-    Enum.map(extra_tools, &normalize_extra_tool/1)
-  end
-
-  defp normalize_extra_tool(%ReqLLM.Tool{} = tool) do
-    {tool, build_extra_tool_callback(tool, nil)}
-  end
-
-  defp normalize_extra_tool({%ReqLLM.Tool{} = tool, callback}) when is_function(callback, 2) do
-    {tool, build_extra_tool_callback(tool, callback)}
-  end
-
-  defp normalize_extra_tool(other) do
-    raise ArgumentError,
-          "Invalid extra tool: #{inspect(other)}. Expected %ReqLLM.Tool{} or {%ReqLLM.Tool{}, callback}"
-  end
-
-  defp build_extra_tool_callback(%ReqLLM.Tool{} = tool, callback_override) do
-    fn arguments, context ->
-      callbacks = context[:tool_callbacks] || %{}
-      tool_name = tool.name
-
-      if on_start = callbacks[:on_tool_start] do
-        on_start.(%ToolStartEvent{
-          tool_name: tool_name,
-          action: nil,
-          resource: nil,
-          arguments: arguments,
-          actor: context[:actor],
-          tenant: context[:tenant]
-        })
-      end
-
-      result =
-        tool
-        |> maybe_override_callback(callback_override, context)
-        |> ReqLLM.Tool.execute(arguments || %{})
-        |> normalize_extra_tool_result()
-
-      if on_end = callbacks[:on_tool_end] do
-        on_end.(%ToolEndEvent{
-          tool_name: tool_name,
-          result: result
-        })
-      end
-
-      result
+      |> build_tools_and_registry()
+      |> elem(0)
     end
-  end
 
-  defp maybe_override_callback(tool, nil, _context), do: tool
-
-  defp maybe_override_callback(tool, callback, context) when is_function(callback, 2) do
-    %{tool | callback: fn arguments -> callback.(arguments, context) end}
-  end
-
-  defp normalize_extra_tool_result({:ok, content}), do: {:ok, content, content}
-
-  defp normalize_extra_tool_result({:error, content}) do
-    {:error, normalize_extra_tool_error(content)}
-  end
-
-  defp ensure_unique_tool_names!(tool_tuples) do
-    duplicates =
-      tool_tuples
-      |> Enum.map(fn {tool, _callback} -> tool.name end)
-      |> Enum.frequencies()
-      |> Enum.filter(fn {_name, count} -> count > 1 end)
-      |> Enum.map(&elem(&1, 0))
-
-    if duplicates == [] do
-      tool_tuples
-    else
-      raise ArgumentError, "Duplicate tool names: #{Enum.join(Enum.sort(duplicates), ", ")}"
+    @doc """
+    Returns a registry map of tool names to callbacks.
+    """
+    def registry(opts) do
+      opts
+      |> build_tools_and_registry()
+      |> elem(1)
     end
-  end
 
-  defp normalize_extra_tool_error(%ReqLLM.ToolResult{} = result), do: result
+    defp build_extra_tools(extra_tools) when is_list(extra_tools) do
+      Enum.map(extra_tools, &normalize_extra_tool/1)
+    end
 
-  defp normalize_extra_tool_error(content) when is_binary(content) or is_list(content),
-    do: content
+    defp normalize_extra_tool(%ReqLLM.Tool{} = tool) do
+      {tool, build_extra_tool_callback(tool, nil)}
+    end
 
-  defp normalize_extra_tool_error(content) when is_map(content) and not is_struct(content) do
-    content
-  end
+    defp normalize_extra_tool({%ReqLLM.Tool{} = tool, callback}) when is_function(callback, 2) do
+      {tool, build_extra_tool_callback(tool, callback)}
+    end
 
-  defp normalize_extra_tool_error(content) do
-    Jason.encode!(%{error: Exception.message(content)})
-  rescue
-    _ -> Jason.encode!(%{error: inspect(content)})
+    defp normalize_extra_tool(other) do
+      raise ArgumentError,
+            "Invalid extra tool: #{inspect(other)}. Expected %ReqLLM.Tool{} or {%ReqLLM.Tool{}, callback}"
+    end
+
+    defp build_extra_tool_callback(%ReqLLM.Tool{} = tool, callback_override) do
+      fn arguments, context ->
+        callbacks = context[:tool_callbacks] || %{}
+        tool_name = tool.name
+
+        if on_start = callbacks[:on_tool_start] do
+          on_start.(%ToolStartEvent{
+            tool_name: tool_name,
+            action: nil,
+            resource: nil,
+            arguments: arguments,
+            actor: context[:actor],
+            tenant: context[:tenant]
+          })
+        end
+
+        result =
+          tool
+          |> maybe_override_callback(callback_override, context)
+          |> ReqLLM.Tool.execute(arguments || %{})
+          |> normalize_extra_tool_result()
+
+        if on_end = callbacks[:on_tool_end] do
+          on_end.(%ToolEndEvent{
+            tool_name: tool_name,
+            result: result
+          })
+        end
+
+        result
+      end
+    end
+
+    defp maybe_override_callback(tool, nil, _context), do: tool
+
+    defp maybe_override_callback(tool, callback, context) when is_function(callback, 2) do
+      %{tool | callback: fn arguments -> callback.(arguments, context) end}
+    end
+
+    defp normalize_extra_tool_result({:ok, content}), do: {:ok, content, content}
+
+    defp normalize_extra_tool_result({:error, content}) do
+      {:error, normalize_extra_tool_error(content)}
+    end
+
+    defp ensure_unique_tool_names!(tool_tuples) do
+      duplicates =
+        tool_tuples
+        |> Enum.map(fn {tool, _callback} -> tool.name end)
+        |> Enum.frequencies()
+        |> Enum.filter(fn {_name, count} -> count > 1 end)
+        |> Enum.map(&elem(&1, 0))
+
+      if duplicates == [] do
+        tool_tuples
+      else
+        raise ArgumentError, "Duplicate tool names: #{Enum.join(Enum.sort(duplicates), ", ")}"
+      end
+    end
+
+    defp normalize_extra_tool_error(%ReqLLM.ToolResult{} = result), do: result
+
+    defp normalize_extra_tool_error(content) when is_binary(content) or is_list(content),
+      do: content
+
+    defp normalize_extra_tool_error(content) when is_map(content) and not is_struct(content) do
+      content
+    end
+
+    defp normalize_extra_tool_error(content) do
+      Jason.encode!(%{error: Exception.message(content)})
+    rescue
+      _ -> Jason.encode!(%{error: inspect(content)})
+    end
+  else
+    def build(%Tool{}, _opts \\ []), do: require_req_llm!()
+    def build_tools_and_registry(_opts), do: require_req_llm!()
+    def list(_opts), do: require_req_llm!()
+    def registry(_opts), do: require_req_llm!()
+
+    defp require_req_llm!, do: AshAi.Dependencies.require_req_llm!("Building ReqLLM tools")
   end
 end

--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.AshAi.Gen.Chat.Docs do
 
     The generator ensures the following dependencies are installed and configured:
 
+    * `req_llm` - for talking to the LLM provider (optional dependency of `ash_ai`)
     * `ash_phoenix` - for forms and code interfaces
     * `ash_oban` - for background job processing
     * `mdex` - for Markdown rendering in the UI
@@ -386,6 +387,13 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp ensure_deps(igniter, otp_app) do
+      {igniter, install_req_llm?} =
+        if Igniter.Project.Deps.has_dep?(igniter, :req_llm) do
+          {igniter, false}
+        else
+          {Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.7"}), true}
+        end
+
       {igniter, install_ash_phoenix?} =
         if Igniter.Project.Deps.has_dep?(igniter, :ash_phoenix) do
           {igniter, false}
@@ -416,7 +424,8 @@ if Code.ensure_loaded?(Igniter) do
 
       igniter
       |> then(fn igniter ->
-        if install_ash_phoenix? || install_ash_oban? || install_mdex? || install_lumis? do
+        if install_req_llm? || install_ash_phoenix? || install_ash_oban? || install_mdex? ||
+             install_lumis? do
           if igniter.assigns[:test_mode?] do
             igniter
           else

--- a/lib/mix/tasks/ash_ai.install.ex
+++ b/lib/mix/tasks/ash_ai.install.ex
@@ -22,6 +22,13 @@ defmodule Mix.Tasks.AshAi.Install.Docs do
     ```bash
     #{example()}
     ```
+
+    ## Options
+
+    * `--no-req-llm` - Skip adding the `req_llm` dependency. `req_llm` is optional in
+      `ash_ai` and only required for features that call an LLM (prompt-backed actions,
+      `AshAi.ToolLoop`, `mix ash_ai.gen.chat`, ReqLLM embeddings). MCP-only setups
+      can omit it.
     """
   end
 end
@@ -39,8 +46,10 @@ if Code.ensure_loaded?(Igniter) do
       %Igniter.Mix.Task.Info{
         group: :ash,
         schema: [
-          yes: :boolean
+          yes: :boolean,
+          req_llm: :boolean
         ],
+        defaults: [req_llm: true],
         installs: [],
         example: __MODULE__.Docs.example()
       }
@@ -50,7 +59,19 @@ if Code.ensure_loaded?(Igniter) do
     def igniter(igniter) do
       igniter
       |> Igniter.Project.Formatter.import_dep(:ash_ai)
+      |> maybe_add_req_llm()
       |> add_dev_mcp()
+    end
+
+    # `req_llm` is an optional dependency of `ash_ai`. It is needed for every
+    # feature that calls an LLM, so we add it by default and let MCP-only users
+    # opt out with `--no-req-llm`.
+    defp maybe_add_req_llm(igniter) do
+      if igniter.args.options[:req_llm] do
+        Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.7"})
+      else
+        igniter
+      end
     end
 
     defp add_dev_mcp(igniter) do

--- a/mix.exs
+++ b/mix.exs
@@ -159,7 +159,7 @@ defmodule AshAi.MixProject do
       {:ash, ash_version("~> 3.0 and >= 3.7.1")},
       {:ash_json_api, "~> 1.4 and >= 1.4.27"},
       {:open_api_spex, "~> 3.0"},
-      {:req_llm, "~> 1.7"},
+      {:req_llm, "~> 1.7", optional: true},
       {:ash_postgres, "~> 2.5", optional: true},
       {:ash_oban, "~> 0.5", optional: true},
       {:ash_phoenix, "~> 2.0", optional: true},

--- a/test/mix/tasks/ash_ai.gen.conversation_test.exs
+++ b/test/mix/tasks/ash_ai.gen.conversation_test.exs
@@ -12,6 +12,14 @@ defmodule Mix.Tasks.AshAi.Gen.ChatTest do
     %{argv: ["--user", "MyApp.Accounts.User", "--extend", "ets"]}
   end
 
+  test "adds req_llm as a dependency", %{argv: argv} do
+    phx_test_project()
+    |> Igniter.compose_task("ash_ai.gen.chat", argv)
+    |> assert_has_patch("mix.exs", """
+    + |      {:req_llm, "~> 1.7"},
+    """)
+  end
+
   test "--live flag doesnt explode", %{argv: argv} do
     argv = argv ++ ["--live"]
 

--- a/test/mix/tasks/ash_ai.install_test.exs
+++ b/test/mix/tasks/ash_ai.install_test.exs
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.AshAi.InstallTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  test "adds req_llm as a dependency by default" do
+    phx_test_project()
+    |> Igniter.compose_task("ash_ai.install", ["--yes"])
+    |> assert_has_patch("mix.exs", """
+    + |      {:req_llm, "~> 1.7"},
+    """)
+  end
+
+  test "--no-req-llm skips adding the req_llm dependency" do
+    igniter =
+      phx_test_project()
+      |> Igniter.compose_task("ash_ai.install", ["--yes", "--no-req-llm"])
+
+    assert_unchanged(igniter, "mix.exs")
+  end
+end


### PR DESCRIPTION
MCP-only users no longer need`req_llm`. LLM-backed modules compile only when `ReqLLM` is available and otherwise raise a descriptive error. The installer adds `req_llm` by default (opt out with `--no-req-llm`).

Closes #207

Ignore whitespace changes when looking at the diff. Otherwise the diff will be massive.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests - testing the absence of an optional dependency is complicated. only tested that part manually.
- [x] Refactoring
- [ ] Update dependencies
