### PR TITLE
fix: preserve assistant history across tool loop rounds

### DIFF
--- a/lib/ash_ai/tool_loop.ex
+++ b/lib/ash_ai/tool_loop.ex
@@ -8,10 +8,13 @@ if Code.ensure_loaded?(ReqLLM) do
     Manages a ReqLLM conversation loop with tool calls.
 
     This module is the primary orchestration API for tool-enabled conversations.
+
+    Each assistant tool-call turn is appended before its tool results. Earlier
+    messages remain unchanged, including their reasoning and provider metadata.
     """
 
     alias ReqLLM.Context
-    alias ReqLLM.Message.ContentPart
+    alias ReqLLM.StreamResponse
 
     defmodule IterationEvent do
       @moduledoc """
@@ -139,12 +142,11 @@ if Code.ensure_loaded?(ReqLLM) do
 
         {:done, [{:error, :max_iterations_reached}], result}
       else
-        case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
-          {:ok, stream_response} ->
-            chunks = Enum.to_list(stream_response.stream)
+        case request_response(req_llm, model, messages, req_llm_opts, tools) do
+          {:ok, stream_response, chunks, response, usage} ->
             content_events = content_events(chunks)
-            chunk_tool_call_ids = chunk_tool_call_ids(chunks)
-            usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
+            assistant = response.message
+            usage_acc = accumulate_usage(usage_acc, usage)
 
             classification =
               stream_response
@@ -154,7 +156,7 @@ if Code.ensure_loaded?(ReqLLM) do
             tool_calls =
               if classification.type == :tool_calls do
                 classification.tool_calls
-                |> normalize_tool_calls(chunk_tool_call_ids)
+                |> normalize_tool_calls()
                 |> unprocessed_tool_calls(messages)
               else
                 []
@@ -169,8 +171,7 @@ if Code.ensure_loaded?(ReqLLM) do
               messages =
                 append_tool_call_turn(
                   messages,
-                  classification.text,
-                  classification.thinking,
+                  assistant,
                   tool_calls
                 )
 
@@ -194,8 +195,8 @@ if Code.ensure_loaded?(ReqLLM) do
               messages =
                 maybe_append_assistant_message(
                   messages,
+                  assistant,
                   classification.text,
-                  classification.thinking,
                   model
                 )
 
@@ -246,14 +247,18 @@ if Code.ensure_loaded?(ReqLLM) do
       end)
     end
 
-    # ReqLLM.StreamResponse.usage/1 awaits a metadata-handle pid; test
-    # fixtures stub the field with non-pid values like `:ignored`, so we
-    # guard against that here rather than failing the whole loop.
-    defp safe_stream_usage(%{metadata_handle: handle} = stream_response) when is_pid(handle) do
-      ReqLLM.StreamResponse.usage(stream_response)
-    end
+    defp request_response(req_llm, model, messages, req_llm_opts, tools) do
+      with {:ok, stream_response} <-
+             req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
+        chunks = Enum.map(stream_response.stream, &normalize_chunk_tool_call_id/1)
+        usage = StreamResponse.usage(stream_response)
 
-    defp safe_stream_usage(_), do: nil
+        with {:ok, response} <-
+               StreamResponse.to_response(%{stream_response | stream: chunks, model: model}) do
+          {:ok, stream_response, chunks, response, usage}
+        end
+      end
+    end
 
     defp run_tools_streaming(tool_calls, messages, registry, ctx) do
       Enum.reduce(tool_calls, {messages, []}, fn tool_call, {msgs, events} ->
@@ -288,7 +293,9 @@ if Code.ensure_loaded?(ReqLLM) do
     defp resolve_model(model, opts) when is_function(model, 1),
       do: resolve_model(model.(opts), opts)
 
-    defp resolve_model(model, _opts) when is_function(model, 0), do: model.()
+    defp resolve_model(model, opts) when is_function(model, 0),
+      do: resolve_model(model.(), opts)
+
     defp resolve_model(model, _opts), do: ReqLLM.model!(model)
 
     defp run_loop(
@@ -307,11 +314,10 @@ if Code.ensure_loaded?(ReqLLM) do
       if max_iterations_reached?(iteration, max_iterations) do
         {:error, :max_iterations_reached}
       else
-        case req_llm.stream_text(model, messages, req_llm_stream_opts(req_llm_opts, tools)) do
-          {:ok, stream_response} ->
-            chunks = Enum.to_list(stream_response.stream)
-            chunk_tool_call_ids = chunk_tool_call_ids(chunks)
-            usage_acc = accumulate_usage(usage_acc, safe_stream_usage(stream_response))
+        case request_response(req_llm, model, messages, req_llm_opts, tools) do
+          {:ok, stream_response, chunks, response, usage} ->
+            assistant = response.message
+            usage_acc = accumulate_usage(usage_acc, usage)
 
             classification =
               stream_response
@@ -321,7 +327,7 @@ if Code.ensure_loaded?(ReqLLM) do
             tool_calls =
               if classification.type == :tool_calls do
                 classification.tool_calls
-                |> normalize_tool_calls(chunk_tool_call_ids)
+                |> normalize_tool_calls()
                 |> unprocessed_tool_calls(messages)
               else
                 []
@@ -336,8 +342,7 @@ if Code.ensure_loaded?(ReqLLM) do
               messages =
                 append_tool_call_turn(
                   messages,
-                  classification.text,
-                  classification.thinking,
+                  assistant,
                   tool_calls
                 )
 
@@ -360,8 +365,8 @@ if Code.ensure_loaded?(ReqLLM) do
               messages =
                 maybe_append_assistant_message(
                   messages,
+                  assistant,
                   classification.text,
-                  classification.thinking,
                   model
                 )
 
@@ -439,55 +444,42 @@ if Code.ensure_loaded?(ReqLLM) do
     defp decode_tool_call_arguments(m) when is_map(m), do: {:ok, m}
     defp decode_tool_call_arguments(_), do: {:ok, %{}}
 
-    defp maybe_append_assistant_message(messages, _text, _thinking, %{provider: :anthropic}),
+    defp maybe_append_assistant_message(messages, _assistant, _text, %{provider: :anthropic}),
       do: messages
 
-    defp maybe_append_assistant_message(messages, text, thinking, _model)
+    defp maybe_append_assistant_message(messages, assistant, text, _model)
          when is_binary(text) and text != "" do
-      content = build_assistant_content(text, thinking)
-      messages ++ [Context.assistant(content)]
+      messages ++ [%{assistant | tool_calls: nil}]
     end
 
     defp maybe_append_assistant_message(messages, _, _, _), do: messages
 
-    defp build_assistant_content(text, thinking) do
-      parts = []
-      parts = if text != "", do: parts ++ [ContentPart.text(text)], else: parts
-
-      parts =
-        if thinking != "", do: parts ++ [ContentPart.thinking(thinking)], else: parts
-
-      parts
+    defp normalize_chunk_tool_call_id(%ReqLLM.StreamChunk{type: :tool_call} = chunk) do
+      metadata = chunk.metadata || %{}
+      id = metadata_field(metadata, :id) || metadata_field(metadata, :call_id)
+      %{chunk | metadata: Map.put(metadata, :id, normalize_tool_call_id(id))}
     end
 
-    defp chunk_tool_call_ids(chunks) do
-      chunks
-      |> Enum.filter(&(&1.type == :tool_call))
-      |> Enum.map(fn chunk ->
-        metadata = chunk.metadata || %{}
-        metadata_field(metadata, :id) || metadata_field(metadata, :call_id)
-      end)
-    end
+    defp normalize_chunk_tool_call_id(chunk), do: chunk
 
-    defp normalize_tool_calls(tool_calls, chunk_tool_call_ids) do
+    defp normalize_tool_calls(tool_calls) do
       tool_calls
       |> List.wrap()
-      |> Enum.with_index()
-      |> Enum.flat_map(fn {tool_call, index} ->
-        case normalize_tool_call(tool_call, Enum.at(chunk_tool_call_ids, index)) do
+      |> Enum.flat_map(fn tool_call ->
+        case normalize_tool_call(tool_call) do
           nil -> []
           normalized -> [normalized]
         end
       end)
     end
 
-    defp normalize_tool_call(%ReqLLM.ToolCall{} = tool_call, chunk_id) do
+    defp normalize_tool_call(%ReqLLM.ToolCall{} = tool_call) do
       tool_call
       |> ReqLLM.ToolCall.to_map()
-      |> normalize_tool_call(chunk_id)
+      |> normalize_tool_call()
     end
 
-    defp normalize_tool_call(tool_call, chunk_id) when is_map(tool_call) do
+    defp normalize_tool_call(tool_call) when is_map(tool_call) do
       name =
         Map.get(tool_call, :name) ||
           Map.get(tool_call, "name") ||
@@ -502,8 +494,7 @@ if Code.ensure_loaded?(ReqLLM) do
           %{}
 
       id =
-        chunk_id ||
-          Map.get(tool_call, :id) ||
+        Map.get(tool_call, :id) ||
           Map.get(tool_call, "id") ||
           Map.get(tool_call, :call_id) ||
           Map.get(tool_call, "call_id")
@@ -519,10 +510,10 @@ if Code.ensure_loaded?(ReqLLM) do
       end
     end
 
-    defp normalize_tool_call(_tool_call, _chunk_id), do: nil
+    defp normalize_tool_call(_tool_call), do: nil
 
     defp normalize_tool_call_id(id) when is_binary(id) and id != "", do: id
-    defp normalize_tool_call_id(id) when is_atom(id), do: Atom.to_string(id)
+    defp normalize_tool_call_id(id) when is_atom(id) and not is_nil(id), do: Atom.to_string(id)
     defp normalize_tool_call_id(id) when is_number(id), do: to_string(id)
     defp normalize_tool_call_id(_), do: generate_tool_id()
 
@@ -537,51 +528,10 @@ if Code.ensure_loaded?(ReqLLM) do
 
     defp normalize_tool_call_arguments(_), do: %{}
 
-    defp append_tool_call_turn(messages, text, thinking, tool_calls) do
-      case merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
-        {:ok, merged_messages} ->
-          merged_messages
-
-        :no_merge ->
-          content = build_assistant_content(text, thinking)
-          messages ++ [Context.assistant(content, tool_calls: tool_calls)]
-      end
-    end
-
-    defp merge_into_previous_tool_turn(messages, text, thinking, tool_calls) do
-      {trailing_tools_rev, rest_rev} =
-        messages
-        |> Enum.reverse()
-        |> Enum.split_while(fn message -> Map.get(message, :role) == :tool end)
-
-      trailing_tools = Enum.reverse(trailing_tools_rev)
-      rest = Enum.reverse(rest_rev)
-
-      case List.last(rest) do
-        %{role: :assistant} = assistant ->
-          if has_tool_calls?(assistant.tool_calls) do
-            prefix = Enum.drop(rest, -1)
-
-            merged_tool_calls =
-              merge_tool_call_lists(
-                assistant.tool_calls,
-                normalize_context_tool_calls(tool_calls)
-              )
-
-            merged_assistant = %{
-              assistant
-              | tool_calls: merged_tool_calls,
-                content: merge_assistant_content(assistant.content, text, thinking)
-            }
-
-            {:ok, prefix ++ [merged_assistant] ++ trailing_tools}
-          else
-            :no_merge
-          end
-
-        _ ->
-          :no_merge
-      end
+    defp append_tool_call_turn(messages, assistant, tool_calls) do
+      ids = MapSet.new(tool_calls, & &1.id)
+      calls = Enum.filter(assistant.tool_calls, &MapSet.member?(ids, &1.id))
+      messages ++ [%{assistant | tool_calls: calls}]
     end
 
     defp unprocessed_tool_calls(tool_calls, messages) do
@@ -600,26 +550,6 @@ if Code.ensure_loaded?(ReqLLM) do
       end)
     end
 
-    defp merge_tool_call_lists(existing, new_calls) do
-      {merged, _seen_ids} =
-        Enum.reduce(List.wrap(existing) ++ List.wrap(new_calls), {[], MapSet.new()}, fn
-          call, {acc, seen} ->
-            case tool_call_id(call) do
-              id when is_binary(id) ->
-                if MapSet.member?(seen, id) do
-                  {acc, seen}
-                else
-                  {acc ++ [call], MapSet.put(seen, id)}
-                end
-
-              _ ->
-                {acc ++ [call], seen}
-            end
-        end)
-
-      merged
-    end
-
     defp tool_call_id(%ReqLLM.ToolCall{} = tool_call), do: tool_call.id
 
     defp tool_call_id(tool_call) when is_map(tool_call) do
@@ -630,60 +560,6 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     defp tool_call_id(_), do: nil
-
-    defp has_tool_calls?(tool_calls) when is_list(tool_calls), do: tool_calls != []
-    defp has_tool_calls?(_), do: false
-
-    defp normalize_context_tool_calls(tool_calls) do
-      Context.assistant("", tool_calls: tool_calls).tool_calls || []
-    end
-
-    defp merge_assistant_content(content, _text, _thinking) when content == [], do: content
-
-    defp merge_assistant_content(content, text, _thinking) when text in [nil, ""], do: content
-
-    defp merge_assistant_content(content, text, thinking) do
-      existing_text = assistant_text(content)
-
-      combined_text =
-        if existing_text == "" do
-          text
-        else
-          existing_text <> "\n" <> text
-        end
-
-      # Preserve non-text content parts (e.g. thinking, images) unless
-      # new thinking is provided, in which case we replace old thinking.
-      other_parts =
-        Enum.reject(content, fn
-          %ContentPart{type: :text} -> true
-          %{type: :text} -> true
-          _ -> false
-        end)
-
-      parts = [ContentPart.text(combined_text)]
-
-      parts =
-        if thinking != "" do
-          parts ++ [ContentPart.thinking(thinking)]
-        else
-          parts ++ other_parts
-        end
-
-      parts
-    end
-
-    defp assistant_text(content_parts) when is_list(content_parts) do
-      content_parts
-      |> Enum.map_join(fn
-        %ContentPart{type: :text, text: text} when is_binary(text) -> text
-        %{type: :text, text: text} when is_binary(text) -> text
-        _ -> ""
-      end)
-      |> String.trim()
-    end
-
-    defp assistant_text(_), do: ""
 
     defp metadata_field(metadata, key) when is_map(metadata) do
       Map.get(metadata, key) || Map.get(metadata, to_string(key))

--- a/test/ash_ai/actions/prompt_test.exs
+++ b/test/ash_ai/actions/prompt_test.exs
@@ -117,7 +117,7 @@ defmodule AshAi.Actions.PromptTest do
            ReqLLM.StreamChunk.tool_call("read_test_resources", %{}),
            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
          ],
-         metadata_handle: :ignored,
+         metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
          cancel: fn -> :ok end,
          model: "openai:gpt-4o",
          context: ReqLLM.Context.new([])
@@ -151,7 +151,7 @@ defmodule AshAi.Actions.PromptTest do
              ),
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: model,
            context: ReqLLM.Context.new(messages)
@@ -163,7 +163,7 @@ defmodule AshAi.Actions.PromptTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: model,
            context: ReqLLM.Context.new(messages)

--- a/test/ash_ai/tool_loop_history_test.exs
+++ b/test/ash_ai/tool_loop_history_test.exs
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAi.ToolLoopHistoryTest do
+  use ExUnit.Case, async: true
+
+  alias AshAi.ToolLoop
+  alias ReqLLM.{Context, Message, StreamChunk}
+
+  defmodule FakeReqLLM do
+    def stream_text(model, messages, _opts) do
+      [{chunks, metadata} | remaining] = Process.get(:history_responses)
+      Process.put(:history_responses, remaining)
+      send(self(), {:history_request, messages})
+
+      stream =
+        Stream.map(chunks, fn chunk ->
+          send(self(), :history_chunk)
+          chunk
+        end)
+
+      {:ok,
+       %ReqLLM.StreamResponse{
+         stream: stream,
+         metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(metadata),
+         cancel: fn -> :ok end,
+         model: model,
+         context: ReqLLM.Context.new(messages)
+       }}
+    end
+  end
+
+  for interface <- [:run, :stream], provider <- [:openai, :anthropic, :openrouter] do
+    @interface interface
+    @provider provider
+
+    test "#{interface}/2 preserves history and reasoning through 16 #{provider} tool rounds" do
+      model = %LLMDB.Model{provider: @provider, id: "history-test"}
+      rounds = Enum.map(1..16, &tool_round(&1, @provider))
+      final_round = {[StreamChunk.text("done")], %{finish_reason: :stop}}
+      Process.put(:history_responses, rounds ++ [final_round])
+      initial = [Context.system("Keep the history."), Context.user("Run the steps.")]
+
+      result = run_loop(@interface, initial, model)
+
+      requests =
+        for _ <- 1..17 do
+          assert_receive {:history_request, messages}
+          messages
+        end
+
+      assert hd(requests) == initial
+
+      for [previous, next] <- Enum.chunk_every(requests, 2, 1, :discard) do
+        assert Enum.take(next, length(previous)) == previous
+        previous_wire = encode(previous, @provider)
+        next_wire = encode(next, @provider)
+        assert Enum.take(next_wire, length(previous_wire)) == previous_wire
+      end
+
+      for {{chunks, metadata}, index} <- Enum.with_index(rounds) do
+        {:ok, expected} =
+          ReqLLM.Provider.ResponseBuilder.for_model(model).build_response(chunks, metadata,
+            model: model,
+            context: Context.new()
+          )
+
+        assert Enum.at(result.messages, 2 + index * 2) == expected.message
+        assert Enum.at(result.messages, 3 + index * 2).tool_call_id == "call_#{index + 1}"
+        assert_receive {:history_tool, %{step: step}}
+        assert step == index + 1
+      end
+
+      assert result.final_text == "done"
+      assert length(result.tool_calls_made) == 16
+      refute_receive {:history_tool, _}
+
+      chunk_count =
+        Enum.sum(Enum.map(rounds ++ [final_round], fn {chunks, _} -> length(chunks) end))
+
+      for _ <- 1..chunk_count, do: assert_receive(:history_chunk)
+      refute_receive :history_chunk
+    end
+  end
+
+  for interface <- [:run, :stream] do
+    @interface interface
+
+    test "#{interface}/2 keeps parallel calls together and filters repeated IDs without changing prior turns" do
+      Process.put(:history_responses, [
+        {[
+           StreamChunk.tool_call("lookup", %{"step" => 1}, %{id: "call_1", index: 0}),
+           StreamChunk.tool_call("lookup", %{"step" => 2}, %{id: "call_2", index: 1})
+         ], %{finish_reason: :tool_calls}},
+        {[
+           StreamChunk.tool_call("lookup", %{"step" => 1}, %{id: "call_1", index: 0}),
+           StreamChunk.tool_call("lookup", %{"step" => 3}, %{id: "call_3", index: 1})
+         ], %{finish_reason: :tool_calls}},
+        {[StreamChunk.tool_call("lookup", %{"step" => 3}, %{id: "call_3", index: 0})],
+         %{finish_reason: :tool_calls}}
+      ])
+
+      initial = [Context.user("Run the steps.")]
+      result = run_loop(@interface, initial, "openai:gpt-4o")
+
+      assert [_, first, result1, result2, second, result3] = result.messages
+      assert Enum.map(first.tool_calls, & &1.id) == ["call_1", "call_2"]
+      assert Enum.map(second.tool_calls, & &1.id) == ["call_3"]
+
+      assert Enum.map([result1, result2, result3], & &1.tool_call_id) == [
+               "call_1",
+               "call_2",
+               "call_3"
+             ]
+
+      for step <- 1..3, do: assert_receive({:history_tool, %{step: ^step}})
+      refute_receive {:history_tool, _}
+      assert length(result.tool_calls_made) == 3
+    end
+
+    test "#{interface}/2 assigns distinct IDs to separate calls without IDs" do
+      Process.put(:history_responses, [
+        {[StreamChunk.tool_call("lookup", %{"step" => 1})], %{finish_reason: :tool_calls}},
+        {[StreamChunk.tool_call("lookup", %{"step" => 2})], %{finish_reason: :tool_calls}},
+        {[StreamChunk.text("done")], %{finish_reason: :stop}}
+      ])
+
+      result = run_loop(@interface, [Context.user("Run the steps.")], "openai:gpt-4o")
+      ids = Enum.map(result.tool_calls_made, & &1.id)
+      assert length(Enum.uniq(ids)) == 2
+      refute "nil" in ids
+      assert [_, first, result1, second, result2, _] = result.messages
+      assert Enum.map(first.tool_calls ++ second.tool_calls, & &1.id) == ids
+      assert Enum.map([result1, result2], & &1.tool_call_id) == ids
+    end
+
+    test "#{interface}/2 returns response materialization errors without executing tools" do
+      Process.put(:history_responses, [
+        {[StreamChunk.tool_call("lookup", %{"step" => 1}, %{id: "call_1"})],
+         %{error: :response_failed}}
+      ])
+
+      opts = loop_opts("openai:gpt-4o")
+
+      case @interface do
+        :run ->
+          assert {:error, :response_failed} = ToolLoop.run([Context.user("Run.")], opts)
+
+        :stream ->
+          events = ToolLoop.stream([Context.user("Run.")], opts) |> Enum.to_list()
+          assert {:error, :response_failed} in events
+          assert {:done, %ToolLoop.Result{}} = List.last(events)
+      end
+
+      refute_receive {:history_tool, _}
+    end
+  end
+
+  defp run_loop(interface, messages, model) do
+    opts = loop_opts(model)
+
+    case interface do
+      :run ->
+        assert {:ok, result} = ToolLoop.run(messages, opts)
+        result
+
+      :stream ->
+        events = ToolLoop.stream(messages, opts) |> Enum.to_list()
+        refute Enum.any?(events, &match?({:error, _}, &1))
+        assert {:done, result} = List.last(events)
+        result
+    end
+  end
+
+  defp loop_opts(model) do
+    [
+      model: fn -> model end,
+      tools: false,
+      max_iterations: 20,
+      req_llm: FakeReqLLM,
+      extra_tools: [
+        ReqLLM.Tool.new!(
+          name: "lookup",
+          description: "Run one test step",
+          parameter_schema: [step: [type: :integer, required: true]],
+          callback: fn args ->
+            send(self(), {:history_tool, args})
+            {:ok, args}
+          end
+        )
+      ]
+    ]
+  end
+
+  defp tool_round(index, provider) do
+    {text, thinking} =
+      case rem(index, 3) do
+        1 -> {"", ""}
+        2 -> {" Step #{index} \n", "Reason #{index}"}
+        0 -> {"", "Reason #{index}"}
+      end
+
+    details =
+      if thinking == "" do
+        []
+      else
+        [
+          %Message.ReasoningDetails{
+            provider: provider,
+            format: "anthropic-v1",
+            index: 0,
+            text: thinking,
+            signature: "signature_#{index}"
+          }
+        ]
+      end
+
+    chunks = [
+      StreamChunk.thinking(thinking),
+      StreamChunk.text(text),
+      StreamChunk.meta(%{reasoning_details: details}),
+      StreamChunk.tool_call("lookup", %{"step" => index}, %{
+        id: "call_#{index}",
+        index: 0,
+        thought_signature: "tool_signature_#{index}"
+      }),
+      StreamChunk.meta(%{finish_reason: :tool_calls})
+    ]
+
+    {chunks, %{finish_reason: :tool_calls, response_id: "response_#{index}"}}
+  end
+
+  defp encode(messages, :anthropic) do
+    ReqLLM.Providers.Anthropic.Context.encode_request(Context.new(messages), "history-test").messages
+  end
+
+  defp encode(messages, _provider) do
+    ReqLLM.Provider.Defaults.encode_context_to_openai_format(
+      Context.new(messages),
+      "history-test"
+    ).messages
+  end
+end

--- a/test/ash_ai/tool_loop_test.exs
+++ b/test/ash_ai/tool_loop_test.exs
@@ -63,7 +63,7 @@ defmodule AshAi.ToolLoopTest do
              },
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -75,7 +75,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -99,7 +99,7 @@ defmodule AshAi.ToolLoopTest do
              }),
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -111,7 +111,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -136,7 +136,7 @@ defmodule AshAi.ToolLoopTest do
                }),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -156,7 +156,7 @@ defmodule AshAi.ToolLoopTest do
                ),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -169,7 +169,7 @@ defmodule AshAi.ToolLoopTest do
                ReqLLM.StreamChunk.text("done"),
                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -194,7 +194,7 @@ defmodule AshAi.ToolLoopTest do
                }),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -222,7 +222,7 @@ defmodule AshAi.ToolLoopTest do
                ),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -235,7 +235,7 @@ defmodule AshAi.ToolLoopTest do
                ReqLLM.StreamChunk.text("done"),
                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -261,7 +261,7 @@ defmodule AshAi.ToolLoopTest do
                }),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -282,7 +282,7 @@ defmodule AshAi.ToolLoopTest do
                ),
                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -295,7 +295,7 @@ defmodule AshAi.ToolLoopTest do
                ReqLLM.StreamChunk.text("done"),
                ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
              ],
-             metadata_handle: :ignored,
+             metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
              cancel: fn -> :ok end,
              model: "openai:gpt-4o",
              context: ReqLLM.Context.new([])
@@ -320,7 +320,7 @@ defmodule AshAi.ToolLoopTest do
              }),
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -332,7 +332,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -400,7 +400,7 @@ defmodule AshAi.ToolLoopTest do
            ReqLLM.StreamChunk.text("done"),
            ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
          ],
-         metadata_handle: :ignored,
+         metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
          cancel: fn -> :ok end,
          model: "openai:gpt-4o",
          context: ReqLLM.Context.new([])
@@ -423,7 +423,7 @@ defmodule AshAi.ToolLoopTest do
              }),
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "anthropic:claude-opus-4-6",
            context: ReqLLM.Context.new([])
@@ -435,7 +435,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "anthropic:claude-opus-4-6",
            context: ReqLLM.Context.new([])
@@ -451,7 +451,7 @@ defmodule AshAi.ToolLoopTest do
          stream: [
            ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
          ],
-         metadata_handle: :ignored,
+         metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
          cancel: fn -> :ok end,
          model: "anthropic:claude-opus-4-6",
          context: ReqLLM.Context.new([])
@@ -474,7 +474,7 @@ defmodule AshAi.ToolLoopTest do
            }),
            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
          ],
-         metadata_handle: :ignored,
+         metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
          cancel: fn -> :ok end,
          model: "openai:gpt-4o",
          context: ReqLLM.Context.new([])
@@ -495,7 +495,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.tool_call("boom", %{}, %{id: "call_boom", index: 0}),
              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_calls})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -507,7 +507,7 @@ defmodule AshAi.ToolLoopTest do
              ReqLLM.StreamChunk.text("done"),
              ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
            ],
-           metadata_handle: :ignored,
+           metadata_handle: AshAi.Test.StreamHelpers.metadata_handle(),
            cancel: fn -> :ok end,
            model: "openai:gpt-4o",
            context: ReqLLM.Context.new([])
@@ -590,7 +590,7 @@ defmodule AshAi.ToolLoopTest do
     assert match?({:done, %ToolLoop.Result{final_text: "done"}}, List.last(events))
   end
 
-  test "run/2 merges sequential tool-call assistant turns into a single pending group" do
+  test "run/2 keeps sequential tool-call assistant turns separate" do
     Process.delete({FakeReqLLMSequentialToolCalls, :call_count})
     messages = [Context.user("trigger tools")]
 
@@ -604,9 +604,11 @@ defmodule AshAi.ToolLoopTest do
     assistant_tool_turns =
       Enum.filter(final_messages, &tool_call?/1)
 
-    assert length(assistant_tool_turns) == 1
+    assert length(assistant_tool_turns) == 2
 
-    assert Enum.map(hd(assistant_tool_turns).tool_calls, & &1.id) == ["call_1", "call_2"]
+    assert Enum.map(assistant_tool_turns, fn message ->
+             Enum.map(message.tool_calls, & &1.id)
+           end) == [["call_1"], ["call_2"]]
 
     tool_result_turns =
       Enum.filter(final_messages, fn message ->
@@ -811,7 +813,7 @@ defmodule AshAi.ToolLoopTest do
     end
   end
 
-  test "run/2 merges tool-call turns even when each turn includes assistant text" do
+  test "run/2 keeps assistant text in its own tool-call turn" do
     Process.delete({FakeReqLLMToolCallsWithInterleavedText, :call_count})
     messages = [Context.user("trigger tools")]
 
@@ -824,7 +826,7 @@ defmodule AshAi.ToolLoopTest do
 
     assistant_tool_turns = Enum.filter(final_messages, &tool_call?/1)
 
-    assert length(assistant_tool_turns) == 1
+    assert length(assistant_tool_turns) == 2
 
     assistant_text =
       assistant_tool_turns
@@ -836,8 +838,12 @@ defmodule AshAi.ToolLoopTest do
       end)
 
     assert assistant_text =~ "First tool pass."
-    assert assistant_text =~ "Second tool pass."
-    assert Enum.map(hd(assistant_tool_turns).tool_calls, & &1.id) == ["call_1", "call_2"]
+    refute assistant_text =~ "Second tool pass."
+    assert [%{text: "Second tool pass."}] = List.last(assistant_tool_turns).content
+
+    assert Enum.map(assistant_tool_turns, fn message ->
+             Enum.map(message.tool_calls, & &1.id)
+           end) == [["call_1"], ["call_2"]]
   end
 
   describe "trailing assistant message handling" do
@@ -978,7 +984,7 @@ defmodule AshAi.ToolLoopTest do
 
       assistant_tool_turns = Enum.filter(final_messages, &tool_call?/1)
 
-      assert length(assistant_tool_turns) == 1
+      assert length(assistant_tool_turns) == 2
 
       assistant_text =
         assistant_tool_turns
@@ -990,7 +996,8 @@ defmodule AshAi.ToolLoopTest do
         end)
 
       assert assistant_text =~ "First tool pass."
-      assert assistant_text =~ "Second tool pass."
+      refute assistant_text =~ "Second tool pass."
+      assert [%{text: "Second tool pass."}] = List.last(assistant_tool_turns).content
 
       assert_tool_results_after_tool_calls(final_messages)
     end

--- a/test/support/stream_helpers.ex
+++ b/test/support/stream_helpers.ex
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024 ash_ai contributors <https://github.com/ash-project/ash_ai/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAi.Test.StreamHelpers do
+  @moduledoc false
+
+  def metadata_handle(metadata \\ %{}) do
+    {:ok, handle} = ReqLLM.StreamResponse.MetadataHandle.start_link(fn -> metadata end)
+    handle
+  end
+end


### PR DESCRIPTION
ToolLoop currently merges later assistant tool turns into the first assistant tool-call message. This changes the history sent on each request, can prevent prompt cache reuse, and can replace or drop earlier reasoning. A dependent sequence such as `assistant(call 1) → result 1 → assistant(call 2) → result 2` becomes `assistant(calls 1 + 2) → result 1 → result 2`.

This change appends each new assistant message before its tool results. It uses the complete ReqLLM response message to retain content, reasoning signatures, and provider metadata. Multiple calls from one response stay together. Existing checks for repeated execution and no-progress termination remain in place.

Call IDs are normalized once before response assembly and classification, so both paths use the same IDs. Model callbacks are resolved to the model struct needed for response assembly. Test responses now supply real metadata handles.

Validation:

- Full suite: 371 passed, 28 live-model tests excluded.
- Focused ToolLoop and prompt-action tests: 53 passed.
- Six history checks fail against the original ToolLoop and pass with this change. They cover 16 tool rounds in both loop interfaces with OpenAI, Anthropic, and OpenRouter model metadata, and compare both message structs and encoded request prefixes.
- Additional tests cover empty content, thinking without visible text, reasoning and tool signatures, parallel calls, repeated IDs, missing IDs, single consumption of the stream, and response assembly errors.
- Compilation with warnings as errors, formatting, Spark formatter, Credo, and Sobelow passed.
- CI Dialyzer and REUSE license checks passed.

Tests use mocked model responses. Local suite setup used an isolated PostgreSQL database with the Oban v14 schema required by the locked Oban dependency. This PR does not change dependencies or database migrations.

CI note: all other CI checks passed. The dependency audit fails on the unchanged dependency lock. Upstream `main` already has an [audit failure](https://github.com/ash-project/ash_ai/actions/runs/33519035546/job/99893304234). The [audit for this PR](https://github.com/ash-project/ash_ai/actions/runs/34033704788/job/101487832970) also includes newer advisories for those locked dependencies.

