### PR TITLE
fix: require ReqLLM 1.18 for signed thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ def deps do
     {:ash_ai, "~> 0.2"},
     # Optional: required for prompt-backed actions, `AshAi.ToolLoop`,
     # `mix ash_ai.gen.chat` and ReqLLM embeddings. Not needed for MCP only.
-    {:req_llm, "~> 1.7"}
+    {:req_llm, "~> 1.18"}
   ]
 end
 ```

--- a/documentation/topics/langchain-to-reqllm-migration.md
+++ b/documentation/topics/langchain-to-reqllm-migration.md
@@ -33,7 +33,7 @@ In `mix.exs`:
 - Add ReqLLM dependency:
 
 ```elixir
-{:req_llm, "~> 1.7"}
+{:req_llm, "~> 1.18"}
 ```
 
 Then fetch and resolve:

--- a/lib/ash_ai/dependencies.ex
+++ b/lib/ash_ai/dependencies.ex
@@ -15,7 +15,7 @@ defmodule AshAi.Dependencies do
 
     Add it to your `mix.exs`:
 
-        {:req_llm, "~> 1.7"}
+        {:req_llm, "~> 1.18"}
 
     then run:
 

--- a/lib/mix/tasks/ash_ai.gen.chat.ex
+++ b/lib/mix/tasks/ash_ai.gen.chat.ex
@@ -391,7 +391,7 @@ if Code.ensure_loaded?(Igniter) do
         if Igniter.Project.Deps.has_dep?(igniter, :req_llm) do
           {igniter, false}
         else
-          {Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.7"}), true}
+          {Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.18"}), true}
         end
 
       {igniter, install_ash_phoenix?} =

--- a/lib/mix/tasks/ash_ai.install.ex
+++ b/lib/mix/tasks/ash_ai.install.ex
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(Igniter) do
     # opt out with `--no-req-llm`.
     defp maybe_add_req_llm(igniter) do
       if igniter.args.options[:req_llm] do
-        Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.7"})
+        Igniter.Project.Deps.add_dep(igniter, {:req_llm, "~> 1.18"})
       else
         igniter
       end

--- a/mix.exs
+++ b/mix.exs
@@ -159,7 +159,7 @@ defmodule AshAi.MixProject do
       {:ash, ash_version("~> 3.0 and >= 3.7.1")},
       {:ash_json_api, "~> 1.4 and >= 1.4.27"},
       {:open_api_spex, "~> 3.0"},
-      {:req_llm, "~> 1.7", optional: true},
+      {:req_llm, "~> 1.18", optional: true},
       {:ash_postgres, "~> 2.5", optional: true},
       {:ash_oban, "~> 0.5", optional: true},
       {:ash_phoenix, "~> 2.0", optional: true},

--- a/test/mix/tasks/ash_ai.gen.conversation_test.exs
+++ b/test/mix/tasks/ash_ai.gen.conversation_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.AshAi.Gen.ChatTest do
     phx_test_project()
     |> Igniter.compose_task("ash_ai.gen.chat", argv)
     |> assert_has_patch("mix.exs", """
-    + |      {:req_llm, "~> 1.7"},
+    + |      {:req_llm, "~> 1.18"},
     """)
   end
 

--- a/test/mix/tasks/ash_ai.install_test.exs
+++ b/test/mix/tasks/ash_ai.install_test.exs
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.AshAi.InstallTest do
     phx_test_project()
     |> Igniter.compose_task("ash_ai.install", ["--yes"])
     |> assert_has_patch("mix.exs", """
-    + |      {:req_llm, "~> 1.7"},
+    + |      {:req_llm, "~> 1.18"},
     """)
   end
 


### PR DESCRIPTION
The complete assistant messages now preserved by #225 need ReqLLM 1.18.0 or later for correct Anthropic signed-thinking continuation. Earlier versions can encode an extra unsigned thinking block next to the signed block, causing the next request to fail. The upstream correction first shipped in 1.18.0: https://github.com/agentjido/req_llm/pull/810.

Raise the ReqLLM requirement to `~> 1.18` and apply the same minimum to the installer, chat generator, dependency message, setup examples, and existing generator tests. The committed lock already selects ReqLLM 1.21.1 and does not change.

Validation:

- Full suite with exactly ReqLLM 1.18.0 and its matching LLMDB 2026.7.5: 371 passed, 28 live tests excluded.
- After restoring the committed lock with ReqLLM 1.21.1: 70 focused ToolLoop, prompt-action, installer, and chat-generator tests passed.
- Compilation with warnings as errors, formatting, and `git diff --check` passed.
- Confirmed that the requirement rejects 1.17.1 and accepts 1.18.0 and 1.21.1.

Local tests used an isolated PostgreSQL database with the Oban v14 schema required by the locked dependency. No live model calls were made.
